### PR TITLE
#43 duplicate zfsprop snapsinazfs.com:lastdailysnapshottimestamp

### DIFF
--- a/Applications/SnapsInAZfs/ConfigConsole/ConfigConsole.cs
+++ b/Applications/SnapsInAZfs/ConfigConsole/ConfigConsole.cs
@@ -1,4 +1,4 @@
-﻿#region MIT LICENSE
+#region MIT LICENSE
 // Copyright 2023 Brandon Thetford
 // 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -24,9 +24,10 @@ namespace SnapsInAZfs.ConfigConsole;
 
 internal static class ConfigConsole
 {
-    private static readonly Logger Logger = LogManager.GetCurrentClassLogger( );
-    internal static IZfsCommandRunner? CommandRunner { get; private set; }
-    internal static ConcurrentDictionary<string, Snapshot> Snapshots { get; } = [];
+    internal const          string                                 ConfigConsoleNamespace = "SnapsInAZfs.ConfigConsole";
+    private static readonly Logger                                 Logger                 = LogManager.GetLogger ( $"{ConfigConsoleNamespace}.{nameof (ConfigConsole)}" )!;
+    internal static         IZfsCommandRunner?                     CommandRunner { get; private set; }
+    internal static         ConcurrentDictionary<string, Snapshot> Snapshots     { get; } = [];
     // ReSharper disable HeapView.ObjectAllocation
     internal static List<TemplateConfigurationListItem> TemplateListItems { get; } = Program.Settings?.Templates.Select( static kvp => new TemplateConfigurationListItem( kvp.Key, kvp.Value with { }, kvp.Value with { } ) ).ToList( ) ?? [];
     // ReSharper restore HeapView.ObjectAllocation

--- a/Applications/SnapsInAZfs/ConfigConsole/ZfsConfigurationWindow.cs
+++ b/Applications/SnapsInAZfs/ConfigConsole/ZfsConfigurationWindow.cs
@@ -29,11 +29,14 @@ using Terminal.Gui.Trees;
 
 namespace SnapsInAZfs.ConfigConsole;
 
+using JetBrains.Annotations;
+
+[MustDisposeResource]
 public sealed partial class ZfsConfigurationWindow
 {
-    private static readonly Logger Logger = LogManager.GetCurrentClassLogger( );
+    private static readonly Logger Logger = LogManager.GetLogger ( $"{ConfigConsole.ConfigConsoleNamespace}{nameof (ZfsConfigurationWindow)}" )!;
 
-    private readonly ConcurrentDictionary<string, ZfsRecord> _treeDatasets = new( );
+    private readonly ConcurrentDictionary<string, ZfsRecord> _treeDatasets = [];
 
     public ZfsConfigurationWindow( )
     {

--- a/Applications/SnapsInAZfs/ConfigConsole/ZfsConfigurationWindow.cs
+++ b/Applications/SnapsInAZfs/ConfigConsole/ZfsConfigurationWindow.cs
@@ -904,7 +904,7 @@ public sealed partial class ZfsConfigurationWindow
             DisableEventHandlers( );
         }
 
-        if ( (ZfsObjectConfigurationTreeNode)zfsTreeView.SelectedObject is not null )
+        if ( (ZfsObjectConfigurationTreeNode)zfsTreeView.SelectedObject is { } )
         {
             ZfsRecord treeDataset = SelectedTreeNode.TreeDataset;
             nameTextField.Text = treeDataset.Name;

--- a/Applications/SnapsInAZfs/SiazService.cs
+++ b/Applications/SnapsInAZfs/SiazService.cs
@@ -462,7 +462,7 @@ public sealed class SiazService : BackgroundService, IApplicationStateObservable
             {
                 Logger.Debug( "Frequent snapshot needed for dataset {0}", ds.Name );
                 ( bool success, Snapshot? snapshot ) = TakeSnapshotKind( ds, SnapshotPeriod.Frequent, propsToSet );
-                if ( success && snapshot is not null )
+                if ( success && snapshot is { } )
                 {
                     snapshots[ snapshot.Name ] = snapshot;
                 }
@@ -472,7 +472,7 @@ public sealed class SiazService : BackgroundService, IApplicationStateObservable
             {
                 Logger.Debug( "Hourly snapshot needed for dataset {0}", ds.Name );
                 ( bool success, Snapshot? snapshot ) = TakeSnapshotKind( ds, SnapshotPeriod.Hourly, propsToSet );
-                if ( success && snapshot is not null )
+                if ( success && snapshot is { } )
                 {
                     snapshots[ snapshot.Name ] = snapshot;
                 }
@@ -482,7 +482,7 @@ public sealed class SiazService : BackgroundService, IApplicationStateObservable
             {
                 Logger.Debug( "Daily snapshot needed for dataset {0}", ds.Name );
                 ( bool success, Snapshot? snapshot ) = TakeSnapshotKind( ds, SnapshotPeriod.Daily, propsToSet );
-                if ( success && snapshot is not null )
+                if ( success && snapshot is { } )
                 {
                     snapshots[ snapshot.Name ] = snapshot;
                 }
@@ -492,7 +492,7 @@ public sealed class SiazService : BackgroundService, IApplicationStateObservable
             {
                 Logger.Debug( "Weekly snapshot needed for dataset {0}", ds.Name );
                 ( bool success, Snapshot? snapshot ) = TakeSnapshotKind( ds, SnapshotPeriod.Weekly, propsToSet );
-                if ( success && snapshot is not null )
+                if ( success && snapshot is { } )
                 {
                     snapshots[ snapshot.Name ] = snapshot;
                 }
@@ -502,7 +502,7 @@ public sealed class SiazService : BackgroundService, IApplicationStateObservable
             {
                 Logger.Debug( "Monthly snapshot needed for dataset {0}", ds.Name );
                 ( bool success, Snapshot? snapshot ) = TakeSnapshotKind( ds, SnapshotPeriod.Monthly, propsToSet );
-                if ( success && snapshot is not null )
+                if ( success && snapshot is { } )
                 {
                     snapshots[ snapshot.Name ] = snapshot;
                 }
@@ -512,7 +512,7 @@ public sealed class SiazService : BackgroundService, IApplicationStateObservable
             {
                 Logger.Debug( "Yearly snapshot needed for dataset {0}", ds.Name );
                 ( bool success, Snapshot? snapshot ) = TakeSnapshotKind( ds, SnapshotPeriod.Yearly, propsToSet );
-                if ( success && snapshot is not null )
+                if ( success && snapshot is { } )
                 {
                     snapshots[ snapshot.Name ] = snapshot;
                 }

--- a/Applications/SnapsInAZfs/SnapsInAZfs.csproj
+++ b/Applications/SnapsInAZfs/SnapsInAZfs.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
+<Project Sdk="Microsoft.NET.Sdk.Worker">
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" IsTrimmable="False" />
   </ItemGroup>
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
-    <LangVersion>13</LangVersion>
+    <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Release-R2R;Debug-Windows;Debug-NoZFS</Configurations>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
-<Project>
+﻿<Project>
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>13</LangVersion>
+    <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Release-R2R;Debug-Windows;Debug-NoZFS</Configurations>

--- a/Libraries/SnapsInAZfs.Interop/SnapsInAZfs.Interop.csproj
+++ b/Libraries/SnapsInAZfs.Interop/SnapsInAZfs.Interop.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <LangVersion>13</LangVersion>
+    <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Release-R2R;Debug-Windows;Debug-NoZFS</Configurations>

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/RawZfsObject.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/RawZfsObject.cs
@@ -24,9 +24,9 @@ namespace SnapsInAZfs.Interop.Zfs.ZfsCommandRunner;
 public sealed class RawZfsObject
 {
     private static readonly Logger          Logger                      = LogManager.GetCurrentClassLogger( );
-    private static readonly HashSet<string> MandatorySnapshotProperties = Enumerable.Union ( IZfsProperty.AllKnownProperties, ["type", "used"] ).ToHashSet ( );
+    private static readonly HashSet<string> MandatorySnapshotProperties = IZfsProperty.KnownSnapshotProperties.Union ( ["type", "used"], StringComparer.OrdinalIgnoreCase ).ToHashSet ( );
 
-    private static readonly HashSet<string> MandatoryZfsRecordProperties = Enumerable.Union ( IZfsProperty.KnownDatasetProperties, ["type", "used", "available"] ).ToHashSet ( );
+    private static readonly HashSet<string> MandatoryZfsRecordProperties = IZfsProperty.KnownDatasetProperties.Union(["type", "used", "available"], StringComparer.OrdinalIgnoreCase).ToHashSet ( );
 
     /// <summary>
     ///     Creates a new instance of a <see cref="RawZfsObject" />

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/RawZfsObject.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/RawZfsObject.cs
@@ -23,10 +23,10 @@ namespace SnapsInAZfs.Interop.Zfs.ZfsCommandRunner;
 /// </summary>
 public sealed class RawZfsObject
 {
-    private static readonly Logger Logger = LogManager.GetCurrentClassLogger( );
-    private static readonly HashSet<string> MandatorySnapshotProperties = IZfsProperty.AllKnownProperties.Union( new[] { "type", "used" } ).ToHashSet( );
+    private static readonly Logger          Logger                      = LogManager.GetCurrentClassLogger( );
+    private static readonly HashSet<string> MandatorySnapshotProperties = Enumerable.Union ( IZfsProperty.AllKnownProperties, ["type", "used"] ).ToHashSet ( );
 
-    private static readonly HashSet<string> MandatoryZfsRecordProperties = IZfsProperty.KnownDatasetProperties.Union( new[] { "type", "used", "available" } ).ToHashSet( );
+    private static readonly HashSet<string> MandatoryZfsRecordProperties = Enumerable.Union ( IZfsProperty.KnownDatasetProperties, ["type", "used", "available"] ).ToHashSet ( );
 
     /// <summary>
     ///     Creates a new instance of a <see cref="RawZfsObject" />
@@ -37,8 +37,8 @@ public sealed class RawZfsObject
         Kind = kind;
     }
 
-    public bool HasAllMandatorySnapshotProperties => !MandatorySnapshotProperties.Except( Properties.Keys ).Any( );
-    public bool HasAllMandatoryZfsRecordProperties => !MandatoryZfsRecordProperties.Except( Properties.Keys ).Any( );
+    public bool HasAllMandatorySnapshotProperties  => !MandatorySnapshotProperties.Except ( Properties.Keys ).Any ( );
+    public bool HasAllMandatoryZfsRecordProperties => !MandatoryZfsRecordProperties.Except ( Properties.Keys ).Any ( );
 
     /// <summary>The string corresponding to the 'type' attribute of a ZFS object</summary>
     public string Kind { get; }

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/ZfsCommandRunner.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/ZfsCommandRunner.cs
@@ -254,14 +254,14 @@ public sealed class ZfsCommandRunner : ZfsCommandRunnerBase, IZfsCommandRunner
     }
 
     /// <inheritdoc />
-    public override async Task GetDatasetsAndSnapshotsFromZfsAsync( SnapsInAZfsSettings settings, ConcurrentDictionary<string, ZfsRecord> datasets, ConcurrentDictionary<string, Snapshot> snapshots )
+    public override async Task GetDatasetsAndSnapshotsFromZfsAsync ( SnapsInAZfsSettings settings, ConcurrentDictionary<string, ZfsRecord> datasets, ConcurrentDictionary<string, Snapshot> snapshots )
     {
-        string propertiesString = IZfsProperty.KnownDatasetProperties.Union( IZfsProperty.KnownSnapshotProperties ).ToCommaSeparatedSingleLineString( );
-        ConfiguredCancelableAsyncEnumerable<string> lineProvider = ZfsExecEnumeratorAsync( "get", $"type,{propertiesString},available,used -H -p -r -t filesystem,volume,snapshot" ).ConfigureAwait( true );
-        SortedDictionary<string, RawZfsObject> rawObjects = new( );
-        await GetRawZfsObjectsAsync( lineProvider, rawObjects ).ConfigureAwait( true );
-        ProcessRawObjects( rawObjects, datasets, snapshots );
-        CheckAndUpdateLastSnapshotTimesForDatasets( settings, datasets );
+        string                                      propertiesString = Enumerable.Union ( IZfsProperty.KnownDatasetProperties, IZfsProperty.KnownSnapshotProperties ).ToCommaSeparatedSingleLineString ( );
+        ConfiguredCancelableAsyncEnumerable<string> lineProvider     = ZfsExecEnumeratorAsync ( "get", $"type,{propertiesString},available,used -H -p -r -t filesystem,volume,snapshot" ).ConfigureAwait ( true );
+        SortedDictionary<string, RawZfsObject>      rawObjects       = new ( );
+        await GetRawZfsObjectsAsync ( lineProvider, rawObjects ).ConfigureAwait ( true );
+        ProcessRawObjects ( rawObjects, datasets, snapshots );
+        CheckAndUpdateLastSnapshotTimesForDatasets ( settings, datasets );
     }
 
     /// <summary>

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/ZfsCommandRunner.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/ZfsCommandRunner.cs
@@ -172,7 +172,7 @@ public sealed class ZfsCommandRunner : ZfsCommandRunnerBase, IZfsCommandRunner
             using ( Process? zfsDestroyProcess = Process.Start( zfsDestroyStartInfo ) )
             {
                 Logger.Debug( "Waiting for {0} {1} to finish", PathToZfsUtility, arguments );
-                if ( zfsDestroyProcess is not null )
+                if ( zfsDestroyProcess is { } )
                 {
                     await zfsDestroyProcess.WaitForExitAsync( ).ConfigureAwait( true );
                     if ( zfsDestroyProcess.ExitCode == 0 )

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/ZfsCommandRunner.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/ZfsCommandRunner.cs
@@ -256,7 +256,7 @@ public sealed class ZfsCommandRunner : ZfsCommandRunnerBase, IZfsCommandRunner
     /// <inheritdoc />
     public override async Task GetDatasetsAndSnapshotsFromZfsAsync ( SnapsInAZfsSettings settings, ConcurrentDictionary<string, ZfsRecord> datasets, ConcurrentDictionary<string, Snapshot> snapshots )
     {
-        string                                      propertiesString = Enumerable.Union ( IZfsProperty.KnownDatasetProperties, IZfsProperty.KnownSnapshotProperties ).ToCommaSeparatedSingleLineString ( );
+        string                                      propertiesString = IZfsProperty.AllKnownProperties.ToCommaSeparatedSingleLineString ( );
         ConfiguredCancelableAsyncEnumerable<string> lineProvider     = ZfsExecEnumeratorAsync ( "get", $"type,{propertiesString},available,used -H -p -r -t filesystem,volume,snapshot" ).ConfigureAwait ( true );
         SortedDictionary<string, RawZfsObject>      rawObjects       = new ( );
         await GetRawZfsObjectsAsync ( lineProvider, rawObjects ).ConfigureAwait ( true );

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/IZfsProperty.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/IZfsProperty.cs
@@ -57,7 +57,7 @@ public interface IZfsProperty
                                                   ZfsPropertyNames.PruneSnapshotsPropertyName
                                               ] );
 
-        AllKnownProperties = KnownDatasetProperties.Union ( KnownSnapshotProperties );
+        AllKnownProperties = Enumerable.Union ( KnownDatasetProperties, KnownSnapshotProperties ).ToImmutableSortedSet ( );
     }
 
     /// <summary>

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/IZfsProperty.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/IZfsProperty.cs
@@ -57,7 +57,7 @@ public interface IZfsProperty
                                                   ZfsPropertyNames.PruneSnapshotsPropertyName
                                               ] );
 
-        AllKnownProperties = Enumerable.Union ( KnownDatasetProperties, KnownSnapshotProperties ).ToImmutableSortedSet ( );
+        AllKnownProperties = KnownDatasetProperties.Union ( KnownSnapshotProperties, StringComparer.OrdinalIgnoreCase ).ToImmutableSortedSet ( );
     }
 
     /// <summary>

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/IZfsProperty.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/IZfsProperty.cs
@@ -2,11 +2,11 @@
 
 // Copyright 2023 Brandon Thetford
 // 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ìSoftwareî), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ‚ÄúSoftware‚Äù), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED ìAS ISî, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED ‚ÄúAS IS‚Äù, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // 
 // See https://opensource.org/license/MIT/
 
@@ -17,41 +17,47 @@ using SnapsInAZfs.Settings.Settings;
 
 namespace SnapsInAZfs.Interop.Zfs.ZfsTypes;
 
+using System.Collections.Frozen;
+
 public interface IZfsProperty
 {
     static IZfsProperty( )
     {
-        KnownDatasetProperties = ImmutableSortedSet<string>.Empty.Union( new[]
-        {
-            ZfsPropertyNames.EnabledPropertyName,
-            ZfsPropertyNames.TakeSnapshotsPropertyName,
-            ZfsPropertyNames.PruneSnapshotsPropertyName,
-            ZfsPropertyNames.RecursionPropertyName,
-            ZfsPropertyNames.SourceSystem,
-            ZfsPropertyNames.TemplatePropertyName,
-            ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName,
-            ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName,
-            ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName,
-            ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName,
-            ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName,
-            ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName,
-            ZfsPropertyNames.SnapshotRetentionFrequentPropertyName,
-            ZfsPropertyNames.SnapshotRetentionHourlyPropertyName,
-            ZfsPropertyNames.SnapshotRetentionDailyPropertyName,
-            ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName,
-            ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName,
-            ZfsPropertyNames.SnapshotRetentionYearlyPropertyName,
-            ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName
-        } );
+        KnownDatasetProperties =
+            ImmutableSortedSet<string>.Empty
+                                      .Union (
+                                              [
+                                                  ZfsPropertyNames.EnabledPropertyName,
+                                                  ZfsPropertyNames.TakeSnapshotsPropertyName,
+                                                  ZfsPropertyNames.PruneSnapshotsPropertyName,
+                                                  ZfsPropertyNames.RecursionPropertyName,
+                                                  ZfsPropertyNames.SourceSystem,
+                                                  ZfsPropertyNames.TemplatePropertyName,
+                                                  ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName,
+                                                  ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName,
+                                                  ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName,
+                                                  ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName,
+                                                  ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName,
+                                                  ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName,
+                                                  ZfsPropertyNames.SnapshotRetentionFrequentPropertyName,
+                                                  ZfsPropertyNames.SnapshotRetentionHourlyPropertyName,
+                                                  ZfsPropertyNames.SnapshotRetentionDailyPropertyName,
+                                                  ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName,
+                                                  ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName,
+                                                  ZfsPropertyNames.SnapshotRetentionYearlyPropertyName,
+                                                  ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName
+                                              ] );
 
-        KnownSnapshotProperties = ImmutableSortedSet<string>.Empty.Union( new[]
-        {
-            ZfsPropertyNames.SnapshotPeriodPropertyName,
-            ZfsPropertyNames.SnapshotTimestampPropertyName,
-            ZfsPropertyNames.PruneSnapshotsPropertyName
-        } );
+        KnownSnapshotProperties =
+            ImmutableSortedSet<string>.Empty
+                                      .Union (
+                                              [
+                                                  ZfsPropertyNames.SnapshotPeriodPropertyName,
+                                                  ZfsPropertyNames.SnapshotTimestampPropertyName,
+                                                  ZfsPropertyNames.PruneSnapshotsPropertyName
+                                              ] );
 
-        AllKnownProperties = KnownDatasetProperties.Union( KnownSnapshotProperties );
+        AllKnownProperties = KnownDatasetProperties.Union ( KnownSnapshotProperties );
     }
 
     /// <summary>
@@ -59,28 +65,30 @@ public interface IZfsProperty
     /// </summary>
     public static ImmutableSortedSet<string> AllKnownProperties { get; }
 
-    public static ImmutableDictionary<string, IZfsProperty> DefaultDatasetProperties { get; } = ImmutableDictionary<string, IZfsProperty>.Empty.AddRange( new Dictionary<string, IZfsProperty>
-    {
-        { ZfsPropertyNames.EnabledPropertyName, ZfsProperty<bool>.CreateWithoutParent( ZfsPropertyNames.EnabledPropertyName, false ) },
-        { ZfsPropertyNames.TakeSnapshotsPropertyName, ZfsProperty<bool>.CreateWithoutParent( ZfsPropertyNames.TakeSnapshotsPropertyName, false ) },
-        { ZfsPropertyNames.PruneSnapshotsPropertyName, ZfsProperty<bool>.CreateWithoutParent( ZfsPropertyNames.PruneSnapshotsPropertyName, false ) },
-        { ZfsPropertyNames.RecursionPropertyName, ZfsProperty<string>.CreateWithoutParent( ZfsPropertyNames.RecursionPropertyName, ZfsPropertyValueConstants.SnapsInAZfs ) },
-        { ZfsPropertyNames.SourceSystem, ZfsProperty<string>.CreateWithoutParent( ZfsPropertyNames.SourceSystem, ZfsPropertyValueConstants.StandaloneSiazSystem ) },
-        { ZfsPropertyNames.TemplatePropertyName, ZfsProperty<string>.CreateWithoutParent( ZfsPropertyNames.TemplatePropertyName, "default" ) },
-        { ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, ZfsProperty<DateTimeOffset>.CreateWithoutParent( ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) },
-        { ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName, ZfsProperty<DateTimeOffset>.CreateWithoutParent( ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) },
-        { ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName, ZfsProperty<DateTimeOffset>.CreateWithoutParent( ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) },
-        { ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, ZfsProperty<DateTimeOffset>.CreateWithoutParent( ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) },
-        { ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName, ZfsProperty<DateTimeOffset>.CreateWithoutParent( ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) },
-        { ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, ZfsProperty<DateTimeOffset>.CreateWithoutParent( ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) },
-        { ZfsPropertyNames.SnapshotRetentionFrequentPropertyName, ZfsProperty<int>.CreateWithoutParent( ZfsPropertyNames.SnapshotRetentionFrequentPropertyName, 0 ) },
-        { ZfsPropertyNames.SnapshotRetentionHourlyPropertyName, ZfsProperty<int>.CreateWithoutParent( ZfsPropertyNames.SnapshotRetentionHourlyPropertyName, 48 ) },
-        { ZfsPropertyNames.SnapshotRetentionDailyPropertyName, ZfsProperty<int>.CreateWithoutParent( ZfsPropertyNames.SnapshotRetentionDailyPropertyName, 90 ) },
-        { ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName, ZfsProperty<int>.CreateWithoutParent( ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName, 0 ) },
-        { ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName, ZfsProperty<int>.CreateWithoutParent( ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName, 6 ) },
-        { ZfsPropertyNames.SnapshotRetentionYearlyPropertyName, ZfsProperty<int>.CreateWithoutParent( ZfsPropertyNames.SnapshotRetentionYearlyPropertyName, 0 ) },
-        { ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, ZfsProperty<int>.CreateWithoutParent( ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, 0 ) }
-    } );
+    // PERFORMANCE: This could be improved by just making it a big struct and eliminating the boxing due to the interface in the dictionary.
+    public static FrozenDictionary<string, IZfsProperty> DefaultDatasetProperties { get; }
+        = new Dictionary<string, IZfsProperty>
+          {
+              { ZfsPropertyNames.EnabledPropertyName, ZfsProperty<bool>.CreateWithoutParent ( ZfsPropertyNames.EnabledPropertyName,               false ) },
+              { ZfsPropertyNames.TakeSnapshotsPropertyName, ZfsProperty<bool>.CreateWithoutParent ( ZfsPropertyNames.TakeSnapshotsPropertyName,   false ) },
+              { ZfsPropertyNames.PruneSnapshotsPropertyName, ZfsProperty<bool>.CreateWithoutParent ( ZfsPropertyNames.PruneSnapshotsPropertyName, false ) },
+              { ZfsPropertyNames.RecursionPropertyName, ZfsProperty<string>.CreateWithoutParent ( ZfsPropertyNames.RecursionPropertyName, ZfsPropertyValueConstants.SnapsInAZfs ) },
+              { ZfsPropertyNames.SourceSystem, ZfsProperty<string>.CreateWithoutParent ( ZfsPropertyNames.SourceSystem,                   ZfsPropertyValueConstants.StandaloneSiazSystem ) },
+              { ZfsPropertyNames.TemplatePropertyName, ZfsProperty<string>.CreateWithoutParent ( ZfsPropertyNames.TemplatePropertyName,   "default" ) },
+              { ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, ZfsProperty<DateTimeOffset>.CreateWithoutParent ( ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) },
+              { ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName, ZfsProperty<DateTimeOffset>.CreateWithoutParent ( ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName,     DateTimeOffset.UnixEpoch ) },
+              { ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName, ZfsProperty<DateTimeOffset>.CreateWithoutParent ( ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName,       DateTimeOffset.UnixEpoch ) },
+              { ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, ZfsProperty<DateTimeOffset>.CreateWithoutParent ( ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName,     DateTimeOffset.UnixEpoch ) },
+              { ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName, ZfsProperty<DateTimeOffset>.CreateWithoutParent ( ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName,   DateTimeOffset.UnixEpoch ) },
+              { ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, ZfsProperty<DateTimeOffset>.CreateWithoutParent ( ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName,     DateTimeOffset.UnixEpoch ) },
+              { ZfsPropertyNames.SnapshotRetentionFrequentPropertyName, ZfsProperty<int>.CreateWithoutParent ( ZfsPropertyNames.SnapshotRetentionFrequentPropertyName,           0 ) },
+              { ZfsPropertyNames.SnapshotRetentionHourlyPropertyName, ZfsProperty<int>.CreateWithoutParent ( ZfsPropertyNames.SnapshotRetentionHourlyPropertyName,               48 ) },
+              { ZfsPropertyNames.SnapshotRetentionDailyPropertyName, ZfsProperty<int>.CreateWithoutParent ( ZfsPropertyNames.SnapshotRetentionDailyPropertyName,                 90 ) },
+              { ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName, ZfsProperty<int>.CreateWithoutParent ( ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName,               0 ) },
+              { ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName, ZfsProperty<int>.CreateWithoutParent ( ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName,             6 ) },
+              { ZfsPropertyNames.SnapshotRetentionYearlyPropertyName, ZfsProperty<int>.CreateWithoutParent ( ZfsPropertyNames.SnapshotRetentionYearlyPropertyName,               0 ) },
+              { ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, ZfsProperty<int>.CreateWithoutParent ( ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, 0 ) }
+          }.ToFrozenDictionary ( );
 
     public static ImmutableSortedDictionary<string, IZfsProperty> DefaultSnapshotProperties { get; } = ImmutableSortedDictionary<string, IZfsProperty>.Empty.AddRange( new Dictionary<string, IZfsProperty>
     {

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/Snapshot.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/Snapshot.cs
@@ -2,11 +2,11 @@
 // 
 // Copyright 2023 Brandon Thetford
 // 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ìSoftwareî), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ‚ÄúSoftware‚Äù), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED ìAS ISî, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED ‚ÄúAS IS‚Äù, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using SnapsInAZfs.Settings.Settings;
 
@@ -200,7 +200,7 @@ public sealed partial record Snapshot : ZfsRecord, IComparable<Snapshot>
         {
             case null:
                 throw new ArgumentNullException( nameof( parent ), "A snapshot must have a parent. Be sure to assign the cloned snapshot to the correct parent." );
-            case not null when parent.GetType( ) != typeof( ZfsRecord ):
+            case { } when parent.GetType( ) != typeof( ZfsRecord ):
                 throw new ArgumentException( "A Snapshot must have a ZfsRecord parent.", nameof( parent ) );
         }
 

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
@@ -2,11 +2,11 @@
 // 
 // Copyright 2023 Brandon Thetford
 // 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ìSoftwareî), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ‚ÄúSoftware‚Äù), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED ìAS ISî, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED ‚ÄúAS IS‚Äù, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
@@ -47,7 +47,7 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
             ZfsPropertyValueConstants.Snapshot => ZfsIdentifierRegexes.SnapshotNameRegex( ),
             _ => throw new InvalidOperationException( "Unknown type of object specified for ZfsIdentifierValidator." )
         };
-        if ( parent is not null && inheritProperties )
+        if ( parent is { } && inheritProperties )
         {
             _enabled = parent.Enabled with { IsLocal = false, Owner = this };
             _lastDailySnapshotTimestamp = parent.LastDailySnapshotTimestamp with { Value = DateTimeOffset.UnixEpoch, IsLocal = true, Owner = this };
@@ -113,7 +113,7 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
             _ => throw new InvalidOperationException( "Unknown type of object specified for ZfsIdentifierValidator." )
         };
         bool notASnapshot = Kind != ZfsPropertyValueConstants.Snapshot;
-        bool isASnapshot = parent is not null && Kind == ZfsPropertyValueConstants.Snapshot;
+        bool isASnapshot  = parent is { } && Kind == ZfsPropertyValueConstants.Snapshot;
 
         if ( forcePropertyOwnership || isASnapshot )
         {
@@ -247,8 +247,8 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
     {
         // Returning equality of value properties alphabetically
         return
-            other is not null
-            && BytesAvailable == other.BytesAvailable
+            other is { }
+         && BytesAvailable == other.BytesAvailable
             && BytesUsed == other.BytesUsed
             && Enabled == other.Enabled
             && IsPoolRoot == other.IsPoolRoot

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
@@ -123,7 +123,7 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
 
             _lastFrequentSnapshotTimestamp = notASnapshot && lastFrequentSnapshotTimestamp.IsLocal
                 ? lastFrequentSnapshotTimestamp with { Owner = this }
-                : new( this, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+                : new( this, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
 
             _lastHourlySnapshotTimestamp = notASnapshot && lastHourlySnapshotTimestamp.IsLocal
                 ? lastHourlySnapshotTimestamp with { Owner = this }

--- a/Libraries/SnapsInAZfs.Monitoring/Monitor.WebApiMethods.cs
+++ b/Libraries/SnapsInAZfs.Monitoring/Monitor.WebApiMethods.cs
@@ -1,4 +1,4 @@
-﻿#region MIT LICENSE
+#region MIT LICENSE
 
 // Copyright 2023 Brandon Thetford
 // 
@@ -27,8 +27,8 @@ public sealed partial class Monitor
         {
             return await Task.FromResult<Results<Ok<string>, StatusCodeHttpResult>>( _applicationStateObservable switch
             {
-                not null => TypedResults.Ok( GetApplicationState( ) ),
-                _ => TypedResults.StatusCode( (int)HttpStatusCode.ServiceUnavailable )
+                { } => TypedResults.Ok( GetApplicationState( ) ),
+                _                                                                            => TypedResults.StatusCode( (int)HttpStatusCode.ServiceUnavailable )
             } ).ConfigureAwait( false );
         }
         catch ( Exception e )
@@ -45,8 +45,8 @@ public sealed partial class Monitor
         {
             return await Task.FromResult<Results<Ok<ApplicationStateMetrics>, StatusCodeHttpResult>>( _applicationStateObservable switch
             {
-                not null => TypedResults.Ok( new ApplicationStateMetrics( GetApplicationState( ), ServiceStartTime, NextRunTime, Environment.WorkingSet, Version ?? "Unknown" ) ),
-                _ => TypedResults.StatusCode( (int)HttpStatusCode.ServiceUnavailable )
+                { } => TypedResults.Ok( new ApplicationStateMetrics( GetApplicationState( ), ServiceStartTime, NextRunTime, Environment.WorkingSet, Version ?? "Unknown" ) ),
+                _                                                                                             => TypedResults.StatusCode( (int)HttpStatusCode.ServiceUnavailable )
             } ).ConfigureAwait( false );
         }
         catch ( Exception e )

--- a/Libraries/SnapsInAZfs.Monitoring/Monitor.cs
+++ b/Libraries/SnapsInAZfs.Monitoring/Monitor.cs
@@ -1,4 +1,4 @@
-﻿#region MIT LICENSE
+#region MIT LICENSE
 
 // Copyright 2023 Brandon Thetford
 // 
@@ -83,7 +83,7 @@ public sealed partial class Monitor : IMonitor
     [SuppressMessage( "ReSharper", "HeapView.DelegateAllocation", Justification = "Event subscription" )]
     public void RegisterApplicationStateObservable( IApplicationStateObservable observableObject, bool subscribeToEvents = true )
     {
-        if ( _applicationStateObservable is not null && !ReferenceEquals( _applicationStateObservable, observableObject ) )
+        if ( _applicationStateObservable is { } && !ReferenceEquals( _applicationStateObservable, observableObject ) )
         {
             throw new InvalidOperationException( "Monitor object has already registered an IApplicationStateObservable instance. Only one is allowed per Monitor object." );
         }
@@ -116,12 +116,12 @@ public sealed partial class Monitor : IMonitor
     [SuppressMessage( "ReSharper", "HeapView.DelegateAllocation", Justification = "Event subscription" )]
     public void RegisterSnapshotOperationsObservable( ISnapshotOperationsObservable observableObject )
     {
-        if ( _snapshotOperationsObservable is not null && !ReferenceEquals( _snapshotOperationsObservable, observableObject ) )
+        if ( _snapshotOperationsObservable is { } && !ReferenceEquals( _snapshotOperationsObservable, observableObject ) )
         {
             throw new InvalidOperationException( "Monitor object has already registered an ISnapshotOperationsObservable instance. Only one is allowed per Monitor object." );
         }
 
-        if ( _snapshotOperationsObservable is not null )
+        if ( _snapshotOperationsObservable is { } )
         {
             return;
         }
@@ -144,7 +144,7 @@ public sealed partial class Monitor : IMonitor
             null => "Not Registered",
             // This warning is obsolete on .net7, as the implementation now caches the strings on first use
             // ReSharper disable HeapView.BoxingAllocation
-            not null when _applicationStateObservableEventSubscribed => _applicationState.ToString( "G" ),
+            { } when _applicationStateObservableEventSubscribed => _applicationState.ToString( "G" ),
             _ => _applicationStateObservable.State.ToString( "G" )
             // ReSharper restore HeapView.BoxingAllocation
         };

--- a/Libraries/SnapsInAZfs.Monitoring/SnapsInAZfs.Monitoring.csproj
+++ b/Libraries/SnapsInAZfs.Monitoring/SnapsInAZfs.Monitoring.csproj
@@ -7,7 +7,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS</DefineConstants>
-    <LangVersion>13</LangVersion>
+    <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Release-R2R;Debug-Windows;Debug-NoZFS</Configurations>

--- a/Libraries/SnapsInAZfs.Settings/SnapsInAZfs.Settings.csproj
+++ b/Libraries/SnapsInAZfs.Settings/SnapsInAZfs.Settings.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
 		<DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS</DefineConstants>
-		<LangVersion>13</LangVersion>
+		<LangVersion>12</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<Configurations>Debug;Release;Release-R2R;Debug-Windows;Debug-NoZFS</Configurations>

--- a/SnapsInAZfs.sln.DotSettings
+++ b/SnapsInAZfs.sln.DotSettings
@@ -612,4 +612,15 @@ See https://opensource.org/license/MIT/</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=whcboe/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=workingset/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=zpool/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=zvol/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=zvol/@EntryIndexedValue">True</s:Boolean>
+  
+  	<s:String x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=49F9F595ACF81E45B2F33CA1F1532FCD/Name/@EntryValue">Performance</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=49F9F595ACF81E45B2F33CA1F1532FCD/Pattern/@EntryValue">(?&lt;=\W|^)(?&lt;TAG&gt;PERFORMANCE|PERF): *(?&lt;Message&gt;[\S].*)$</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=49F9F595ACF81E45B2F33CA1F1532FCD/TodoIconStyle/@EntryValue">Warning</s:String>
+	<s:String x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=49F9F595ACF81E45B2F33CA1F1532FCD/Color/@EntryValue">#FFFF6200</s:String>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=49F9F595ACF81E45B2F33CA1F1532FCD/@KeyIndexDefined">True</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=49F9F595ACF81E45B2F33CA1F1532FCD/CaseSensitive/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=49F9F595ACF81E45B2F33CA1F1532FCD/MatchComments/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/PatternsAndTemplates/Todo/TodoPatterns/=49F9F595ACF81E45B2F33CA1F1532FCD/MatchStrings/@EntryValue">True</s:Boolean>
+
+</wpf:ResourceDictionary>

--- a/Tests/SnapsInAZfs.Interop.Tests/SnapsInAZfs.Interop.Tests.csproj
+++ b/Tests/SnapsInAZfs.Interop.Tests/SnapsInAZfs.Interop.Tests.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>13</LangVersion>
+    <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Release-R2R;Debug-Windows;Debug-NoZFS</Configurations>

--- a/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsCommandRunner/RawZfsObjectTests.cs
+++ b/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsCommandRunner/RawZfsObjectTests.cs
@@ -1,4 +1,4 @@
-﻿#region MIT LICENSE
+#region MIT LICENSE
 
 // Copyright 2023 Brandon Thetford
 // 
@@ -562,13 +562,13 @@ public class RawZfsObjectTests
         } );
     }
 
-    private static TestCaseData[] GetAddRawProperty_TestCases( )
+    private static TestCaseData [] GetAddRawProperty_TestCases ( )
     {
-        return IZfsProperty.KnownDatasetProperties.Union( IZfsProperty.KnownSnapshotProperties ).Select( kp => new TestCaseData( kp, $"{kp} value", ZfsPropertySourceConstants.Local ) )
-                           .Prepend( new( "type", ZfsPropertyValueConstants.FileSystem, ZfsPropertySourceConstants.None ) )
-                           .Append( new( "available", "54321", ZfsPropertySourceConstants.None ) )
-                           .Append( new( "used", "12345", ZfsPropertySourceConstants.None ) )
-                           .ToArray( );
+        return IZfsProperty.AllKnownProperties.Select ( static kp => new TestCaseData ( kp, $"{kp} value", ZfsPropertySourceConstants.Local ) )
+                           .Prepend ( new ( "type", ZfsPropertyValueConstants.FileSystem, ZfsPropertySourceConstants.None ) )
+                           .Append ( new ( "available", "54321", ZfsPropertySourceConstants.None ) )
+                           .Append ( new ( "used", "12345", ZfsPropertySourceConstants.None ) )
+                           .ToArray ( );
     }
 
     private static ZfsRecord GetTestRootRecord( )

--- a/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsCommandRunner/TestCommandRunner.cs
+++ b/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsCommandRunner/TestCommandRunner.cs
@@ -1,4 +1,4 @@
-﻿// LICENSE:
+// LICENSE:
 // 
 // This software is licensed for use under the Free Software Foundation's GPL v3.0 license
 
@@ -24,7 +24,7 @@ public class TestCommandRunner : ZfsCommandRunnerBase
 
     public override async Task GetDatasetsAndSnapshotsFromZfsAsync(SnapsInAZfsSettings settings, ConcurrentDictionary<string, ZfsRecord> datasets, ConcurrentDictionary<string, Snapshot> snapshots)
     {
-        string propertiesString = IZfsProperty.KnownDatasetProperties.Union(IZfsProperty.KnownSnapshotProperties).ToCommaSeparatedSingleLineString();
+        string propertiesString = IZfsProperty.AllKnownProperties.ToCommaSeparatedSingleLineString();
         Logger.Debug("Pretending to run zfs get type,{0},available,used -H -p -r -t filesystem,volume,snapshot", propertiesString);
         ConfiguredCancelableAsyncEnumerable<string> lineProvider = ZfsExecEnumeratorAsync("get", "testData-WithSnapshotsToPrune.txt").ConfigureAwait(true);
         SortedDictionary<string, RawZfsObject> rawObjects = new();

--- a/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsPropertyTests/ZfsPropertyTests.cs
+++ b/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsPropertyTests/ZfsPropertyTests.cs
@@ -1,4 +1,4 @@
-﻿// LICENSE:
+// LICENSE:
 // 
 // This software is licensed for use under the Free Software Foundation's GPL v3.0 license
 
@@ -502,6 +502,14 @@ public class ZfsPropertyTests
     {
         ZfsProperty<string> zfsProperty = ZfsProperty<string>.CreateWithoutParent( "someName", testValue );
         Assert.That( zfsProperty.ValueString, Is.EqualTo( testValue ) );
+    }
+
+    [Test]
+    public void AllKnownProperties_ContainsOnlyUniqueValues ( )
+    {
+        Assume.That ( IZfsProperty.KnownDatasetProperties,  Is.Unique );
+        Assume.That ( IZfsProperty.KnownSnapshotProperties, Is.Unique );
+        Assert.That ( IZfsProperty.AllKnownProperties, Is.Unique );
     }
 
     private static TestCaseData[] BoolEqualityTestCaseData( )

--- a/Tests/SnapsInAZfs.Monitoring.Tests/SnapsInAZfs.Monitoring.Tests.csproj
+++ b/Tests/SnapsInAZfs.Monitoring.Tests/SnapsInAZfs.Monitoring.Tests.csproj
@@ -4,7 +4,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>13</LangVersion>
+    <LangVersion>12</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Configurations>Debug;Release;Release-R2R;Debug-Windows;Debug-NoZFS</Configurations>

--- a/Tests/SnapsInAZfs.Tests/ProgramTests.cs
+++ b/Tests/SnapsInAZfs.Tests/ProgramTests.cs
@@ -255,7 +255,7 @@ public class ProgramTests
 
     private static void ResetNLogToNoOutput( )
     {
-        if ( LogManager.Configuration is not null )
+        if ( LogManager.Configuration is { } )
         {
             LogManager.Shutdown( );
         }


### PR DESCRIPTION
Fixes issue #43 

The real root of the problem was one line in the equality comparison of ZfsRecord, which could result in certain combinations of frequent and daily snapshots making the `snapsinazfs.com:lastdailysnapshottimestamp` get inserted into the zfs command twice, if a dataset with frequent and daily snapshots also had one or more ***descendent*** datasets with a frequent snapshot.

It's a pretty specific case to test, but I put it on my todo list for creating a test case for it in the future and will file an issue for it specifically if other refactors don't end up making it irrelevant anyway. I want to be sure the test case is meaningful, valuable, and reasonable, if I end up needing one.

siaz-2.1 will be rebased on top of this as well, so there's probably going to be a force push as a heads up for anyone who cares.