### PR TITLE
Siaz 2.0 housekeeping round 1

### DIFF
--- a/Applications/SnapsInAZfs/SiazService.cs
+++ b/Applications/SnapsInAZfs/SiazService.cs
@@ -176,7 +176,7 @@ public sealed class SiazService : BackgroundService, IApplicationStateObservable
 
             foreach ( ( string propName, _ ) in IZfsProperty.DefaultDatasetProperties )
             {
-                if ( !propName.StartsWith( ZfsPropertyNames.SiazNamespace ) || propertyValidities.ContainsKey( propName ) )
+                if ( !propName.StartsWith( ZfsPropertyNames.SiazZfsPropNamespace ) || propertyValidities.ContainsKey( propName ) )
                 {
                     continue;
                 }

--- a/Libraries/SnapsInAZfs.Interop/SnapsInAZfs.Interop.csproj
+++ b/Libraries/SnapsInAZfs.Interop/SnapsInAZfs.Interop.csproj
@@ -54,6 +54,7 @@
   </ItemGroup>
   
   <ItemGroup>
+    <Using Include="NLog" />
     <Using Include="SnapsInAZfs.Settings.Settings" />
   </ItemGroup>
 

--- a/Libraries/SnapsInAZfs.Interop/SnapsInAZfs.Interop.csproj
+++ b/Libraries/SnapsInAZfs.Interop/SnapsInAZfs.Interop.csproj
@@ -52,6 +52,10 @@
   <ItemGroup>
     <ProjectReference Include="..\SnapsInAZfs.Settings\SnapsInAZfs.Settings.csproj" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <Using Include="SnapsInAZfs.Settings.Settings" />
+  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="SnapsInAZfs.Settings.Tests" />

--- a/Libraries/SnapsInAZfs.Interop/StringConstants.cs
+++ b/Libraries/SnapsInAZfs.Interop/StringConstants.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SnapsInAZfs.Interop
+{
+    /// <summary>
+    /// Internal class for common string constants.
+    /// </summary>
+    /// <remarks>In future .net versions, most or all of this will likely go away with improvements to `nameof` to work with namespaces.</remarks>
+    internal static class StringConstants
+    {
+        internal const string SnapsInAZfsNamespace = "SnapsInAZfs";
+        internal const string InteropNamespace     = $"{SnapsInAZfsNamespace}.Interop";
+        internal const string ZfsNamespace         = $"{InteropNamespace}.Zfs";
+        internal const string ZfsTypesNamespace    = $"{ZfsNamespace}.ZfsTypes";
+    }
+}

--- a/Libraries/SnapsInAZfs.Interop/StringConstants.cs
+++ b/Libraries/SnapsInAZfs.Interop/StringConstants.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace SnapsInAZfs.Interop
 {
     /// <summary>

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/IZfsCommandRunner.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/IZfsCommandRunner.cs
@@ -2,18 +2,16 @@
 // 
 // Copyright 2023 Brandon Thetford
 // 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ìSoftwareî), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ‚ÄúSoftware‚Äù), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED ìAS ISî, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED ‚ÄúAS IS‚Äù, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Text.Json;
-using NLog;
 using SnapsInAZfs.Interop.Zfs.ZfsTypes;
-using SnapsInAZfs.Settings.Settings;
 
 namespace SnapsInAZfs.Interop.Zfs.ZfsCommandRunner;
 

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/RawZfsObject.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/RawZfsObject.cs
@@ -13,7 +13,6 @@
 #endregion
 
 using System.Collections.Concurrent;
-using NLog;
 using SnapsInAZfs.Interop.Zfs.ZfsTypes;
 
 namespace SnapsInAZfs.Interop.Zfs.ZfsCommandRunner;

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/ZfsCommandRunner.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/ZfsCommandRunner.cs
@@ -16,9 +16,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using NLog;
 using SnapsInAZfs.Interop.Zfs.ZfsTypes;
-using SnapsInAZfs.Settings.Settings;
 
 namespace SnapsInAZfs.Interop.Zfs.ZfsCommandRunner;
 

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/ZfsCommandRunnerBase.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsCommandRunner/ZfsCommandRunnerBase.cs
@@ -2,11 +2,11 @@
 
 // Copyright 2023 Brandon Thetford
 // 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ìSoftwareî), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the ‚ÄúSoftware‚Äù), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED ìAS ISî, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED ‚ÄúAS IS‚Äù, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // 
 // See https://opensource.org/license/MIT/
 
@@ -14,9 +14,7 @@
 
 using System.Collections.Concurrent;
 using System.Runtime.CompilerServices;
-using NLog;
 using SnapsInAZfs.Interop.Zfs.ZfsTypes;
-using SnapsInAZfs.Settings.Settings;
 
 namespace SnapsInAZfs.Interop.Zfs.ZfsCommandRunner;
 

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/IZfsProperty.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/IZfsProperty.cs
@@ -12,12 +12,10 @@
 
 #endregion
 
+using System.Collections.Frozen;
 using System.Collections.Immutable;
-using SnapsInAZfs.Settings.Settings;
 
 namespace SnapsInAZfs.Interop.Zfs.ZfsTypes;
-
-using System.Collections.Frozen;
 
 public interface IZfsProperty
 {

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/IZfsProperty.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/IZfsProperty.cs
@@ -1,12 +1,12 @@
 #region MIT LICENSE
 
-// Copyright 2023 Brandon Thetford
+// Copyright 2025 Brandon Thetford
 // 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // 
 // See https://opensource.org/license/MIT/
 
@@ -21,7 +21,7 @@ using System.Collections.Frozen;
 
 public interface IZfsProperty
 {
-    static IZfsProperty( )
+    static IZfsProperty ( )
     {
         KnownDatasetProperties =
             ImmutableSortedSet<string>.Empty
@@ -61,7 +61,7 @@ public interface IZfsProperty
     }
 
     /// <summary>
-    ///     Gets the union of <see cref="KnownDatasetProperties" /> and <see cref="KnownSnapshotProperties" />
+    ///     Gets the union of <see cref="KnownDatasetProperties"/> and <see cref="KnownSnapshotProperties"/>
     /// </summary>
     public static ImmutableSortedSet<string> AllKnownProperties { get; }
 
@@ -90,21 +90,19 @@ public interface IZfsProperty
               { ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, ZfsProperty<int>.CreateWithoutParent ( ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, 0 ) }
           }.ToFrozenDictionary ( );
 
-    public static ImmutableSortedDictionary<string, IZfsProperty> DefaultSnapshotProperties { get; } = ImmutableSortedDictionary<string, IZfsProperty>.Empty.AddRange( new Dictionary<string, IZfsProperty>
-    {
-        { ZfsPropertyNames.SnapshotPeriodPropertyName, ZfsProperty<string>.CreateWithoutParent( ZfsPropertyNames.SnapshotPeriodPropertyName, SnapshotPeriod.NotSet ) },
-        { ZfsPropertyNames.SnapshotTimestampPropertyName, ZfsProperty<DateTimeOffset>.CreateWithoutParent( ZfsPropertyNames.SnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) }
-    } );
+    public static ImmutableSortedDictionary<string, IZfsProperty> DefaultSnapshotProperties { get; } = ImmutableSortedDictionary<string, IZfsProperty>.Empty.AddRange (
+                                                                                                                                                                       new Dictionary<string, IZfsProperty>
+                                                                                                                                                                       {
+                                                                                                                                                                           { ZfsPropertyNames.SnapshotPeriodPropertyName, ZfsProperty<string>.CreateWithoutParent ( ZfsPropertyNames.SnapshotPeriodPropertyName, SnapshotPeriod.NotSet ) },
+                                                                                                                                                                           { ZfsPropertyNames.SnapshotTimestampPropertyName, ZfsProperty<DateTimeOffset>.CreateWithoutParent ( ZfsPropertyNames.SnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) }
+                                                                                                                                                                       } );
 
-    public bool IsLocal { get; init; }
-    public static ImmutableSortedSet<string> KnownDatasetProperties { get; }
-
+    bool                                     IsLocal                 { get; init; }
+    public static ImmutableSortedSet<string> KnownDatasetProperties  { get; }
     public static ImmutableSortedSet<string> KnownSnapshotProperties { get; }
-
-    string Name { get; }
-
-    public ZfsRecord? Owner { get; set; }
-    string SetString { get; }
-    string Source { get; }
-    string ValueString { get; }
+    string                                   Name                    { get; }
+    public ZfsRecord?                        Owner                   { get; init; }
+    string                                   SetString               { get; }
+    string                                   Source                  { get; }
+    string                                   ValueString             { get; }
 }

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/Snapshot.ZfsProps.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/Snapshot.ZfsProps.cs
@@ -1,14 +1,16 @@
-// LICENSE:
+#region MIT LICENSE
+
+// Copyright 2025 Brandon Thetford
 // 
-// Copyright 2023 Brandon Thetford
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+// See https://opensource.org/license/MIT/
 
-using NLog;
+#endregion
 
 namespace SnapsInAZfs.Interop.Zfs.ZfsTypes;
 

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/Snapshot.ZfsProps.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/Snapshot.ZfsProps.cs
@@ -16,54 +16,62 @@ namespace SnapsInAZfs.Interop.Zfs.ZfsTypes;
 
 public sealed partial record Snapshot
 {
-    private static readonly Logger Logger = LogManager.GetCurrentClassLogger( );
-    private readonly ZfsProperty<string> _period;
-    private readonly ZfsProperty<DateTimeOffset> _timestamp;
+    private static readonly Logger Logger = LogManager.GetLogger ( $"{StringConstants.ZfsTypesNamespace}.{nameof (Snapshot)}" )!;
 
-    public ref readonly ZfsProperty<string> Period => ref _period;
-
+    private readonly    ZfsProperty<string>         _period;
+    private readonly    ZfsProperty<DateTimeOffset> _timestamp;
+    public ref readonly ZfsProperty<string>         Period    => ref _period;
     public ref readonly ZfsProperty<DateTimeOffset> Timestamp => ref _timestamp;
 
+    /// <summary>
+    ///     Updates the property with the specified <paramref name="propertyName"/> and returns a <see langword="ref"/> to the updated
+    ///     property.
+    /// </summary>
     /// <exception cref="Exception">A delegate callback throws an exception.</exception>
     /// <exception cref="ArgumentOutOfRangeException">If an attempt is made to change the Timestamp or Period properties</exception>
-    public override ref readonly ZfsProperty<string> UpdateProperty( string propertyName, string propertyValue, bool isLocal = true )
+    public override ref readonly ZfsProperty<string> UpdateProperty ( string propertyName, string propertyValue, bool isLocal = true )
     {
         // ReSharper disable once ConvertSwitchStatementToSwitchExpression
         switch ( propertyName )
         {
             case ZfsPropertyNames.SnapshotPeriodPropertyName:
-                throw new ArgumentOutOfRangeException( nameof( propertyName ), "Snapshot period cannot be changed." );
+                throw new ArgumentOutOfRangeException ( nameof (propertyName), "Snapshot period cannot be changed." );
             default:
-                return ref base.UpdateProperty( propertyName, propertyValue, isLocal );
+                return ref base.UpdateProperty ( propertyName, propertyValue, isLocal );
         }
     }
 
+    /// <summary>
+    ///     Updates the property with the specified <paramref name="propertyName"/> and returns a <see langword="ref"/> to the updated
+    ///     property.
+    /// </summary>
     /// <exception cref="ArgumentOutOfRangeException">If an attempt is made to change the Timestamp property</exception>
-    public override ref readonly ZfsProperty<DateTimeOffset> UpdateProperty( string propertyName, in DateTimeOffset propertyValue, bool isLocal = true )
+    public override ref readonly ZfsProperty<DateTimeOffset> UpdateProperty ( string propertyName, in DateTimeOffset propertyValue, bool isLocal = true )
     {
         // ReSharper disable once ConvertSwitchStatementToSwitchExpression
         switch ( propertyName )
         {
             case ZfsPropertyNames.SnapshotTimestampPropertyName:
-                throw new ArgumentOutOfRangeException( nameof( propertyName ), "Snapshot timestamp cannot be changed." );
+                throw new ArgumentOutOfRangeException ( nameof (propertyName), "Snapshot timestamp cannot be changed." );
             default:
-                return ref base.UpdateProperty( propertyName, propertyValue, isLocal );
+                return ref base.UpdateProperty ( propertyName, propertyValue, isLocal );
         }
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     /// <exception cref="Exception">A delegate callback throws an exception.</exception>
-    protected override void OnParentUpdatedStringProperty( ZfsRecord sender, ref ZfsProperty<string> updatedProperty )
+    protected override void OnParentUpdatedStringProperty ( ZfsRecord sender, ref ZfsProperty<string> updatedProperty )
     {
-        Logger.Trace( "{2} received string property change event for {0} from {1}", updatedProperty.Name, sender.Name, Name );
+        Logger.Trace ( "{2} received string property change event for {0} from {1}", updatedProperty.Name, sender.Name, Name );
+
         if ( updatedProperty.Name switch
-            {
-                ZfsPropertyNames.TemplatePropertyName => Template.IsInherited,
-                ZfsPropertyNames.RecursionPropertyName => Recursion.IsInherited,
-                _ => throw new ArgumentOutOfRangeException( nameof( updatedProperty ), "Unsupported property name {0} when updating string property", updatedProperty.Name )
-            } )
+             {
+                 ZfsPropertyNames.TemplatePropertyName  => Template.IsInherited,
+                 ZfsPropertyNames.RecursionPropertyName => Recursion.IsInherited,
+                 _                                      => throw new ArgumentOutOfRangeException ( nameof (updatedProperty), "Unsupported property name {0} when updating string property", updatedProperty.Name )
+             } )
         {
-            UpdateProperty( updatedProperty.Name, updatedProperty.Value, false );
+            UpdateProperty ( updatedProperty.Name, updatedProperty.Value, false );
         }
     }
 }

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/Snapshot.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/Snapshot.cs
@@ -1,68 +1,53 @@
-// LICENSE:
+#region MIT LICENSE
+
+// Copyright 2025 Brandon Thetford
 // 
-// Copyright 2023 Brandon Thetford
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+// See https://opensource.org/license/MIT/
 
-using SnapsInAZfs.Settings.Settings;
+#endregion
 
 namespace SnapsInAZfs.Interop.Zfs.ZfsTypes;
 
-public sealed partial record Snapshot : ZfsRecord, IComparable<Snapshot>
+using System.Numerics;
+
+public sealed partial record Snapshot : ZfsRecord, IComparable<Snapshot>, IEqualityOperators<Snapshot, Snapshot, bool>
 {
     /// <summary>
-    /// Creates a new snapshot with the given values and all other properties inherited from <paramref name="parentDataset"/>
+    ///     Creates a new snapshot from all properties
     /// </summary>
-    /// <param name="name">The name of the <see cref="Snapshot"/></param>
-    /// <param name="periodKind">The <see cref="SnapshotPeriodKind"/> of the <see cref="Snapshot"/></param>
-    /// <param name="sourceSystem">The <see cref="ZfsRecord.SourceSystem"/> property to use for the new <see cref="Snapshot"/></param>
-    /// <param name="timestamp">The timestamp of the <see cref="Snapshot"/></param>
-    /// <param name="parentDataset">The <see cref="ZfsRecord"/> this <see cref="Snapshot"/> belongs to</param>
-    /// <remarks>
-    /// The <see cref="ZfsRecord.Recursion">Recursion</see> and <see cref="ZfsRecord.Template">Template</see> properties will be set to local.
-    /// </remarks>
-    /// <exception cref="ArgumentException">sourceSystem must have a non-null, non-whitespace-only Value</exception>
-    public Snapshot( string name, in SnapshotPeriodKind periodKind, in ZfsProperty<string> sourceSystem, in DateTimeOffset timestamp, ZfsRecord parentDataset )
-        : this(
-            name,
-            parentDataset.Enabled,
-            parentDataset.TakeSnapshots,
-            parentDataset.PruneSnapshots,
-            parentDataset.LastFrequentSnapshotTimestamp,
-            parentDataset.LastHourlySnapshotTimestamp,
-            parentDataset.LastDailySnapshotTimestamp,
-            parentDataset.LastWeeklySnapshotTimestamp,
-            parentDataset.LastMonthlySnapshotTimestamp,
-            parentDataset.LastYearlySnapshotTimestamp,
-            parentDataset.Recursion,
-            parentDataset.Template,
-            parentDataset.SnapshotRetentionFrequent,
-            parentDataset.SnapshotRetentionHourly,
-            parentDataset.SnapshotRetentionDaily,
-            parentDataset.SnapshotRetentionWeekly,
-            parentDataset.SnapshotRetentionMonthly,
-            parentDataset.SnapshotRetentionYearly,
-            parentDataset.SnapshotRetentionPruneDeferral,
-            sourceSystem,
-            (SnapshotPeriod)periodKind,
-            timestamp,
-            parentDataset )
-    {
-        if ( string.IsNullOrWhiteSpace( sourceSystem.Value ) )
-        {
-            throw new ArgumentException( "sourceSystem must have a non-null, non-whitespace-only Value", nameof( sourceSystem ) );
-        }
-    }
-
-    /// <summary>
-    /// Creates a new snapshot from all properties
-    /// </summary>
-    public Snapshot( string snapName, in ZfsProperty<bool> enabled, in ZfsProperty<bool> takeSnapshots, in ZfsProperty<bool> pruneSnapshots, in ZfsProperty<DateTimeOffset> lastFrequentSnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastHourlySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastDailySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastWeeklySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastMonthlySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastYearlySnapshotTimestamp, in ZfsProperty<string> recursion, in ZfsProperty<string> template, in ZfsProperty<int> retentionFrequent, in ZfsProperty<int> retentionHourly, in ZfsProperty<int> retentionDaily, in ZfsProperty<int> retentionWeekly, in ZfsProperty<int> retentionMonthly, in ZfsProperty<int> retentionYearly, in ZfsProperty<int> retentionPruneDeferral, in ZfsProperty<string> sourceSystem, in string snapshotPeriod, in DateTimeOffset snapshotTimestamp, ZfsRecord parent )
-        : base( snapName,
+    public Snapshot (
+        string                         snapName,
+        in ZfsProperty<bool>           enabled,
+        in ZfsProperty<bool>           takeSnapshots,
+        in ZfsProperty<bool>           pruneSnapshots,
+        in ZfsProperty<DateTimeOffset> lastFrequentSnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastHourlySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastDailySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastWeeklySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastMonthlySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastYearlySnapshotTimestamp,
+        in ZfsProperty<string>         recursion,
+        in ZfsProperty<string>         template,
+        in ZfsProperty<int>            retentionFrequent,
+        in ZfsProperty<int>            retentionHourly,
+        in ZfsProperty<int>            retentionDaily,
+        in ZfsProperty<int>            retentionWeekly,
+        in ZfsProperty<int>            retentionMonthly,
+        in ZfsProperty<int>            retentionYearly,
+        in ZfsProperty<int>            retentionPruneDeferral,
+        in ZfsProperty<string>         sourceSystem,
+        in string                      snapshotPeriod,
+        in DateTimeOffset              snapshotTimestamp,
+        ZfsRecord                      parent
+    )
+        : base (
+                snapName,
                 ZfsPropertyValueConstants.Snapshot,
                 enabled,
                 takeSnapshots,
@@ -88,22 +73,70 @@ public sealed partial record Snapshot : ZfsRecord, IComparable<Snapshot>
                 parent,
                 true )
     {
-        if ( string.IsNullOrWhiteSpace( sourceSystem.Value ) )
+        if ( string.IsNullOrWhiteSpace ( sourceSystem.Value ) )
         {
-            throw new ArgumentException( "sourceSystem must have a non-null, non-whitespace-only Value", nameof( sourceSystem ) );
+            throw new ArgumentException ( "sourceSystem must have a non-null, non-whitespace-only Value", nameof (sourceSystem) );
         }
-        _period = new( this, ZfsPropertyNames.SnapshotPeriodPropertyName, snapshotPeriod );
-        _timestamp = new( this, ZfsPropertyNames.SnapshotTimestampPropertyName, snapshotTimestamp );
+
+        _period    = new ( this, ZfsPropertyNames.SnapshotPeriodPropertyName, snapshotPeriod );
+        _timestamp = new ( this, ZfsPropertyNames.SnapshotTimestampPropertyName, snapshotTimestamp );
     }
 
     /// <summary>
-    ///     Compares the current instance with another <see cref="Snapshot" /> and returns an integer that indicates
-    ///     whether the current instance precedes, follows, or occurs in the same position in the sort order as the other
-    ///     <see cref="Snapshot" />.
+    ///     Creates a new snapshot with the given values and all other properties inherited from <paramref name="parentDataset"/>
     /// </summary>
-    /// <param name="other">Another <see cref="Snapshot" /> to compare with this instance.</param>
+    /// <param name="name">The name of the <see cref="Snapshot"/></param>
+    /// <param name="periodKind">The <see cref="SnapshotPeriodKind"/> of the <see cref="Snapshot"/></param>
+    /// <param name="sourceSystem">
+    ///     The <see cref="ZfsRecord.SourceSystem"/> property to use for the new <see cref="Snapshot"/>
+    /// </param>
+    /// <param name="timestamp">The timestamp of the <see cref="Snapshot"/></param>
+    /// <param name="parentDataset">The <see cref="ZfsRecord"/> this <see cref="Snapshot"/> belongs to</param>
+    /// <remarks>
+    ///     The <see cref="ZfsRecord.Recursion">Recursion</see> and <see cref="ZfsRecord.Template">Template</see> properties will be set
+    ///     to local.
+    /// </remarks>
+    /// <exception cref="ArgumentException">sourceSystem must have a non-null, non-whitespace-only Value</exception>
+    public Snapshot ( string name, in SnapshotPeriodKind periodKind, in ZfsProperty<string> sourceSystem, in DateTimeOffset timestamp, ZfsRecord parentDataset )
+        : this (
+                name,
+                parentDataset.Enabled,
+                parentDataset.TakeSnapshots,
+                parentDataset.PruneSnapshots,
+                parentDataset.LastFrequentSnapshotTimestamp,
+                parentDataset.LastHourlySnapshotTimestamp,
+                parentDataset.LastDailySnapshotTimestamp,
+                parentDataset.LastWeeklySnapshotTimestamp,
+                parentDataset.LastMonthlySnapshotTimestamp,
+                parentDataset.LastYearlySnapshotTimestamp,
+                parentDataset.Recursion,
+                parentDataset.Template,
+                parentDataset.SnapshotRetentionFrequent,
+                parentDataset.SnapshotRetentionHourly,
+                parentDataset.SnapshotRetentionDaily,
+                parentDataset.SnapshotRetentionWeekly,
+                parentDataset.SnapshotRetentionMonthly,
+                parentDataset.SnapshotRetentionYearly,
+                parentDataset.SnapshotRetentionPruneDeferral,
+                sourceSystem,
+                (SnapshotPeriod)periodKind,
+                timestamp,
+                parentDataset )
+    {
+        if ( string.IsNullOrWhiteSpace ( sourceSystem.Value ) )
+        {
+            throw new ArgumentException ( "sourceSystem must have a non-null, non-whitespace-only Value", nameof (sourceSystem) );
+        }
+    }
+
+    /// <summary>
+    ///     Compares the current instance with another <see cref="Snapshot"/> and returns an integer that indicates
+    ///     whether the current instance precedes, follows, or occurs in the same position in the sort order as the other
+    ///     <see cref="Snapshot"/>.
+    /// </summary>
+    /// <param name="other">Another <see cref="Snapshot"/> to compare with this instance.</param>
     /// <returns>
-    ///     A value that indicates the relative order of the <see cref="Snapshot" />s being compared. The return value
+    ///     A value that indicates the relative order of the <see cref="Snapshot"/>s being compared. The return value
     ///     has
     ///     these meanings:
     ///     <list type="table">
@@ -112,17 +145,17 @@ public sealed partial record Snapshot : ZfsRecord, IComparable<Snapshot>
     ///         </listheader>
     ///         <item>
     ///             <term> Less than zero</term>
-    ///             <description> This instance precedes <paramref name="other" /> in the sort order.</description>
+    ///             <description> This instance precedes <paramref name="other"/> in the sort order.</description>
     ///         </item>
     ///         <item>
     ///             <term> Zero</term>
     ///             <description>
-    ///                 This instance occurs in the same position in the sort order as <paramref name="other" />.
+    ///                 This instance occurs in the same position in the sort order as <paramref name="other"/>.
     ///             </description>
     ///         </item>
     ///         <item>
     ///             <term> Greater than zero</term>
-    ///             <description> This instance follows <paramref name="other" /> in the sort order.</description>
+    ///             <description> This instance follows <paramref name="other"/> in the sort order.</description>
     ///         </item>
     ///     </list>
     /// </returns>
@@ -133,37 +166,37 @@ public sealed partial record Snapshot : ZfsRecord, IComparable<Snapshot>
     ///             <term>Condition</term><description>Result</description>
     ///         </listheader>
     ///         <item>
-    ///             <term>Other <see cref="Snapshot" /> is null or has a null <see cref="Timestamp" /></term>
+    ///             <term>Other <see cref="Snapshot"/> is null or has a null <see cref="Timestamp"/></term>
     ///             <description>
-    ///                 This <see cref="Snapshot" /> precedes <paramref name="other" /> in the sort order.
+    ///                 This <see cref="Snapshot"/> precedes <paramref name="other"/> in the sort order.
     ///             </description>
     ///         </item>
     ///         <item>
-    ///             <term><see cref="Timestamp" /> of this <see cref="Snapshot" /> is null</term>
+    ///             <term><see cref="Timestamp"/> of this <see cref="Snapshot"/> is null</term>
     ///             <description>
-    ///                 This <see cref="Snapshot" /> follows <paramref name="other" /> in the sort order.
+    ///                 This <see cref="Snapshot"/> follows <paramref name="other"/> in the sort order.
     ///             </description>
     ///         </item>
     ///         <item>
-    ///             <term><see cref="Timestamp" /> of each <see cref="Snapshot" /> is different</term>
+    ///             <term><see cref="Timestamp"/> of each <see cref="Snapshot"/> is different</term>
     ///             <description>
-    ///                 Sort by <see cref="Timestamp" />, using system rules for the <see cref="DateTimeOffset" />
+    ///                 Sort by <see cref="Timestamp"/>, using system rules for the <see cref="DateTimeOffset"/>
     ///                 type
     ///             </description>
     ///         </item>
     ///         <item>
-    ///             <term><see cref="Period" /> of each <see cref="Snapshot" /> is different</term>
+    ///             <term><see cref="Period"/> of each <see cref="Snapshot"/> is different</term>
     ///             <description>
-    ///                 Delegate sort order to <see cref="SnapshotPeriod" />, using <see cref="Period" /> of each
+    ///                 Delegate sort order to <see cref="SnapshotPeriod"/>, using <see cref="Period"/> of each
     ///             </description>
     ///         </item>
     ///         <item>
-    ///             <term><see cref="Period" />s of both <see cref="Snapshot" />s are equal</term>
-    ///             <description>Sort by <see cref="ZfsRecord.Name" /></description>
+    ///             <term><see cref="Period"/>s of both <see cref="Snapshot"/>s are equal</term>
+    ///             <description>Sort by <see cref="ZfsRecord.Name"/></description>
     ///         </item>
     ///     </list>
     /// </remarks>
-    public int CompareTo( Snapshot? other )
+    public int CompareTo ( Snapshot? other )
     {
         // If the other snapshot is null, consider this snapshot earlier rank
         if ( other?.Timestamp is null )
@@ -174,38 +207,62 @@ public sealed partial record Snapshot : ZfsRecord, IComparable<Snapshot>
         // If timestamps are different, sort on timestamps
         if ( other.Timestamp.Value != Timestamp.Value )
         {
-            return Timestamp.Value.CompareTo( other.Timestamp.Value );
+            return Timestamp.Value.CompareTo ( other.Timestamp.Value );
         }
 
         // If timestamps are different, sort on period, by its SnapshotPeriodKind equivalent
-        return !Period.Value.Equals( other.Period.Value )
-            ? Period.Value.ToSnapshotPeriodKind( ).CompareTo( other.Period.Value.ToSnapshotPeriodKind( ) )
-            : string.Compare( Name, other.Name, StringComparison.Ordinal );
+        return !Period.Value.Equals ( other.Period.Value )
+                   ? Period.Value.ToSnapshotPeriodKind ( ).CompareTo ( other.Period.Value.ToSnapshotPeriodKind ( ) )
+                   : string.Compare ( Name, other.Name, StringComparison.Ordinal );
+    }
+
+    /// <inheritdoc/>
+    bool IEquatable<Snapshot?>.Equals ( Snapshot? other )
+    {
+        if ( other is null )
+        {
+            return false;
+        }
+
+        if ( ReferenceEquals ( this, other ) )
+        {
+            return true;
+        }
+
+        return _period.Equals ( other._period )
+            && Timestamp.Equals ( other._timestamp )
+            && Enabled.Equals ( other.Enabled )
+            && Kind == other.Kind
+            && Name == other.Name
+            && PruneSnapshots.Equals ( other.PruneSnapshots )
+            && Recursion.Equals ( other.Recursion )
+            && Template.Equals ( other.Template );
     }
 
     /// <summary>
-    ///     Performs a deep copy of this <see cref="Snapshot" />
+    ///     Performs a deep copy of this <see cref="Snapshot"/>
     /// </summary>
     /// <param name="parent">
-    ///     A reference to the parent of the new <see cref="Snapshot" />
+    ///     A reference to the parent of the new <see cref="Snapshot"/>
     /// </param>
     /// <returns>
-    ///     A new instance of a <see cref="ZfsRecord" />, with all properties, both reference and value, cloned to new instances
+    ///     A new instance of a <see cref="ZfsRecord"/>, with all properties, both reference and value, cloned to new instances
     /// </returns>
     /// <exception cref="ArgumentException"><paramref name="parent"/> is any type other than <see cref="ZfsRecord"/></exception>
     /// <exception cref="ArgumentNullException"><paramref name="parent"/> is null</exception>
-    public override Snapshot DeepCopyClone( ZfsRecord? parent = null )
+    public override Snapshot DeepCopyClone ( ZfsRecord? parent = null )
     {
         switch ( parent )
         {
             case null:
-                throw new ArgumentNullException( nameof( parent ), "A snapshot must have a parent. Be sure to assign the cloned snapshot to the correct parent." );
-            case { } when parent.GetType( ) != typeof( ZfsRecord ):
-                throw new ArgumentException( "A Snapshot must have a ZfsRecord parent.", nameof( parent ) );
+                throw new ArgumentNullException ( nameof (parent), "A snapshot must have a parent. Be sure to assign the cloned snapshot to the correct parent." );
+            case { } when parent.GetType ( ) != typeof (ZfsRecord):
+                throw new ArgumentException ( "A Snapshot must have a ZfsRecord parent.", nameof (parent) );
         }
 
         // Pass the original references, because the constructor will copy them and set ownership appropriately.
-        Snapshot newSnapshot = new( new( Name ),
+        Snapshot newSnapshot = new (
+                                    new ( Name ),
                                     Enabled,
                                     TakeSnapshots,
                                     PruneSnapshots,
@@ -228,63 +285,32 @@ public sealed partial record Snapshot : ZfsRecord, IComparable<Snapshot>
                                     Period.Value,
                                     Timestamp.Value,
                                     parent );
+
         return newSnapshot;
     }
 
-    public string GetSnapshotOptionsStringForZfsSnapshot( )
+    public bool Equals ( Snapshot other )
     {
-        return $"-o {Period.SetString} -o {Timestamp.SetString} -o {Recursion.SetString} -o {SourceSystem.SetString}";
-    }
-
-    /// <inheritdoc />
-    public override string ToString( )
-    {
-        return $"{Name}";
-    }
-
-    /// <inheritdoc />
-    bool IEquatable<Snapshot?>.Equals( Snapshot? other )
-    {
-        if ( other is null )
-        {
-            return false;
-        }
-
-        if ( ReferenceEquals( this, other ) )
+        if ( ReferenceEquals ( this, other ) )
         {
             return true;
         }
 
-        return _period.Equals( other._period )
-               && Timestamp.Equals( other._timestamp )
-               && Enabled.Equals( other.Enabled )
-               && Kind == other.Kind
-               && Name == other.Name
-               && PruneSnapshots.Equals( other.PruneSnapshots )
-               && Recursion.Equals( other.Recursion )
-               && Template.Equals( other.Template );
+        return _period.Equals ( other._period )
+            && Timestamp.Equals ( other._timestamp )
+            && Enabled.Equals ( other.Enabled )
+            && Kind == other.Kind
+            && Name == other.Name
+            && PruneSnapshots.Equals ( other.PruneSnapshots )
+            && Recursion.Equals ( other.Recursion )
+            && Template.Equals ( other.Template );
     }
 
-    public bool Equals( Snapshot other )
-    {
-        if ( ReferenceEquals( this, other ) )
-        {
-            return true;
-        }
+    /// <inheritdoc/>
+    public override int GetHashCode ( ) => HashCode.Combine ( base.GetHashCode ( ), _period, Name, _timestamp );
 
-        return _period.Equals( other._period )
-               && Timestamp.Equals( other._timestamp )
-               && Enabled.Equals( other.Enabled )
-               && Kind == other.Kind
-               && Name == other.Name
-               && PruneSnapshots.Equals( other.PruneSnapshots )
-               && Recursion.Equals( other.Recursion )
-               && Template.Equals( other.Template );
-    }
+    public string GetSnapshotOptionsStringForZfsSnapshot ( ) => $"-o {Period.SetString} -o {Timestamp.SetString} -o {Recursion.SetString} -o {SourceSystem.SetString}";
 
-    /// <inheritdoc />
-    public override int GetHashCode( )
-    {
-        return HashCode.Combine( base.GetHashCode( ), _period, Name, _timestamp );
-    }
+    /// <inheritdoc/>
+    public override string ToString ( ) => $"{Name}";
 }

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/TypeExtensions.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/TypeExtensions.cs
@@ -1,14 +1,16 @@
-// LICENSE:
+#region MIT LICENSE
+
+// Copyright 2025 Brandon Thetford
 // 
-// Copyright 2023 Brandon Thetford
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+// See https://opensource.org/license/MIT/
 
-using SnapsInAZfs.Settings.Settings;
+#endregion
 
 namespace SnapsInAZfs.Interop.Zfs.ZfsTypes;
 
@@ -19,126 +21,130 @@ public static class TypeExtensions
 {
     /// <summary>
     ///     Gets an integer index for radio button groups assuming the order of true, false from this
-    ///     <see cref="ZfsProperty{T}" />
+    ///     <see cref="ZfsProperty{T}"/>
     /// </summary>
     /// <param name="property">
-    ///     The <see cref="ZfsProperty{T}" /> to convert to an integer index for radio button groups
+    ///     The <see cref="ZfsProperty{T}"/> to convert to an integer index for radio button groups
     /// </param>
     /// <returns>
-    ///     An <see langword="int" /> representing the index in a radio button group for this property's source<br />
-    ///     0: true<br />
-    ///     1: false<br />
+    ///     An <see langword="int"/> representing the index in a radio button group for this property's source<br/>
+    ///     0: true<br/>
+    ///     1: false<br/>
     /// </returns>
-    public static int AsTrueFalseRadioIndex( this ZfsProperty<bool> property )
-    {
-        return property.Value ? 0 : 1;
-    }
+    public static int AsTrueFalseRadioIndex ( this ZfsProperty<bool> property ) => property.Value ? 0 : 1;
 
-    public static string GetMostRecentSnapshotZfsPropertyName( this SnapshotPeriod period )
+    public static string GetMostRecentSnapshotZfsPropertyName ( this SnapshotPeriod period )
     {
         return period.Kind switch
-        {
-            SnapshotPeriodKind.Frequent => ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName,
-            SnapshotPeriodKind.Hourly => ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName,
-            SnapshotPeriodKind.Daily => ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName,
-            SnapshotPeriodKind.Weekly => ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName,
-            SnapshotPeriodKind.Monthly => ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName,
-            SnapshotPeriodKind.Yearly => ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName,
-            SnapshotPeriodKind.NotSet => throw new ArgumentOutOfRangeException( nameof( period ) ),
-            _ => throw new FormatException( "Unrecognized SnapshotPeriod value" )
-        };
+               {
+                   SnapshotPeriodKind.Frequent => ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName,
+                   SnapshotPeriodKind.Hourly   => ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName,
+                   SnapshotPeriodKind.Daily    => ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName,
+                   SnapshotPeriodKind.Weekly   => ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName,
+                   SnapshotPeriodKind.Monthly  => ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName,
+                   SnapshotPeriodKind.Yearly   => ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName,
+                   SnapshotPeriodKind.NotSet   => throw new ArgumentOutOfRangeException ( nameof (period) ),
+                   _                           => throw new FormatException ( "Unrecognized SnapshotPeriod value" )
+               };
     }
 
-    public static string GetZfsPathParent( this string value )
+    public static string GetZfsPathParent ( this string value )
     {
-        int endIndex = value.LastIndexOfAny( ['/', '@', '#'] );
+        int endIndex = value.LastIndexOfAny ( [ '/', '@', '#' ] );
 
         return endIndex == -1
-            ?
-            // This is a pool root.
-            // Returned value is the same as input
-            value
-            :
-            // This is a non-root dataset, snapshot, or bookmark
-            // Return its parent dataset name
-            // ReSharper disable once HeapView.ObjectAllocation
-            value[ ..endIndex ];
-    }
+                   ?
 
-    public static bool IsNotWanted( this ZfsProperty<int> retentionProperty )
-    {
-        return retentionProperty.Value == 0;
-    }
+                   // This is a pool root.
+                   // Returned value is the same as input
+                   value
+                   :
 
-    public static bool IsWanted( this ZfsProperty<int> retentionProperty )
-    {
-        return retentionProperty.Value != 0;
-    }
-
-    /// <exception cref="OutOfMemoryException">
-    ///     The length of the resulting string overflows the maximum allowed length (
-    ///     <see cref="System.Int32.MaxValue">Int32.MaxValue</see>).
-    /// </exception>
-    public static string ToCommaSeparatedSingleLineString( this IEnumerable<string> strings, bool withSpaces = false )
-    {
-        return withSpaces ? string.Join( ", ", strings ) : string.Join( ',', strings );
-    }
-
-    /// <exception cref="OutOfMemoryException">
-    ///     The length of the resulting string overflows the maximum allowed length (
-    ///     <see cref="System.Int32.MaxValue">Int32.MaxValue</see>).
-    /// </exception>
-    public static string ToCommaSeparatedSingleLineString( this IEnumerable<ZfsRecord> records, bool withSpaces = false )
-    {
-        return ToCommaSeparatedSingleLineString( records.Order( ).Select( static r => r.Name ), withSpaces );
-    }
-
-    /// <exception cref="OutOfMemoryException">
-    ///     The length of the resulting string overflows the maximum allowed length (
-    ///     <see cref="System.Int32.MaxValue">Int32.MaxValue</see>).
-    /// </exception>
-    public static string ToNewlineSeparatedString( this IEnumerable<string> strings )
-    {
-        return string.Join( '\n', strings );
-    }
-
-    public static SnapshotPeriodKind ToSnapshotPeriodKind( this string input )
-    {
-        return SnapshotPeriod.StringToSnapshotPeriodKind( input );
-    }
-
-    /// <exception cref="OutOfMemoryException">
-    ///     The length of the resulting string overflows the maximum allowed length (
-    ///     <see cref="System.Int32.MaxValue">Int32.MaxValue</see>).
-    /// </exception>
-    public static string ToSpaceSeparatedSingleLineString( this IEnumerable<string> strings )
-    {
-        return string.Join( ' ', strings );
-    }
-
-    public static string ToStringForZfsSet( this IEnumerable<IZfsProperty> properties )
-    {
-        return properties.Select( static p => p.SetString ).ToSpaceSeparatedSingleLineString( );
+                   // This is a non-root dataset, snapshot, or bookmark
+                   // Return its parent dataset name
+                   // ReSharper disable once HeapView.ObjectAllocation
+                   value [ ..endIndex ];
     }
 
     /// <summary>
-    ///     Gets a string of all <see cref="IZfsProperty.SetString" /> values, separated by spaces, to be used in zfs set
+    ///     Returns a boolean indicating whether <paramref name="retentionProperty"/> is NOT wanted, by checking if its value is 0.
+    /// </summary>
+    public static bool IsNotWanted ( this ZfsProperty<int> retentionProperty ) => retentionProperty.Value == 0;
+
+    /// <summary>
+    ///     Returns a boolean indicating whether <paramref name="retentionProperty"/> IS wanted, by checking if its value is not 0.
+    /// </summary>
+    public static bool IsWanted ( this ZfsProperty<int> retentionProperty ) => retentionProperty.Value != 0;
+
+    /// <summary>
+    ///     Totally unnecessary convenience proxy method for
+    ///     <see cref="string.Join(string?,System.Collections.Generic.IEnumerable{string?})"/>
+    /// </summary>
+    /// <exception cref="OutOfMemoryException">
+    ///     The length of the resulting string overflows the maximum allowed length (
+    ///     <see cref="System.Int32.MaxValue">Int32.MaxValue</see>).
+    /// </exception>
+    public static string ToCommaSeparatedSingleLineString ( this IEnumerable<string> strings, bool withSpaces = false ) => withSpaces ? string.Join ( ", ", strings ) : string.Join ( ',', strings );
+
+    /// <summary>
+    ///     Totally unnecessary convenience proxy method for
+    ///     <see cref="string.Join(string?,System.Collections.Generic.IEnumerable{string?})"/>
+    /// </summary>
+    /// <exception cref="OutOfMemoryException">
+    ///     The length of the resulting string overflows the maximum allowed length (
+    ///     <see cref="System.Int32.MaxValue">Int32.MaxValue</see>).
+    /// </exception>
+    public static string ToCommaSeparatedSingleLineString ( this IEnumerable<ZfsRecord> records, bool withSpaces = false ) { return ToCommaSeparatedSingleLineString ( records.Order ( ).Select ( static r => r.Name ), withSpaces ); }
+
+    /// <summary>
+    ///     Totally unnecessary convenience proxy method for
+    ///     <see cref="string.Join(string?,System.Collections.Generic.IEnumerable{string?})"/>
+    /// </summary>
+    /// <exception cref="OutOfMemoryException">
+    ///     The length of the resulting string overflows the maximum allowed length (
+    ///     <see cref="System.Int32.MaxValue">Int32.MaxValue</see>).
+    /// </exception>
+    public static string ToNewlineSeparatedString ( this IEnumerable<string> strings ) => string.Join ( '\n', strings );
+
+    /// <summary>
+    ///     Reflection-free conversion of string to <see cref="SnapshotPeriodKind"/>.
+    /// </summary>
+    public static SnapshotPeriodKind ToSnapshotPeriodKind ( this string input ) => SnapshotPeriod.StringToSnapshotPeriodKind ( input );
+
+    /// <summary>
+    ///     Totally unnecessary convenience proxy method for
+    ///     <see cref="string.Join(string?,System.Collections.Generic.IEnumerable{string?})"/>
+    /// </summary>
+    /// <exception cref="OutOfMemoryException">
+    ///     The length of the resulting string overflows the maximum allowed length (
+    ///     <see cref="System.Int32.MaxValue">Int32.MaxValue</see>).
+    /// </exception>
+    public static string ToSpaceSeparatedSingleLineString ( this IEnumerable<string> strings ) => string.Join ( ' ', strings );
+
+    /// <summary>
+    ///     Totally unnecessary convenience proxy method for
+    ///     <see cref="string.Join(string?,System.Collections.Generic.IEnumerable{string?})"/>
+    /// </summary>
+    public static string ToStringForZfsSet ( this IEnumerable<IZfsProperty> properties ) { return properties.Select ( static p => p.SetString ).ToSpaceSeparatedSingleLineString ( ); }
+
+    /// <summary>
+    ///     Gets a string of all <see cref="IZfsProperty.SetString"/> values, separated by spaces, to be used in zfs set
     ///     operations
     /// </summary>
     /// <param name="properties">
-    ///     An <see cref="IEnumerable{T}" /> of <see cref="IZfsProperty" /> objects to get a set string
+    ///     An <see cref="IEnumerable{T}"/> of <see cref="IZfsProperty"/> objects to get a set string
     ///     for
     /// </param>
     /// <returns></returns>
-    public static string ToStringForZfsSet( this List<IZfsProperty> properties )
+    public static string ToStringForZfsSet ( this List<IZfsProperty> properties )
     {
-        ArgumentNullException.ThrowIfNull( properties, nameof( properties ) );
+        ArgumentNullException.ThrowIfNull ( properties, nameof (properties) );
 
-        if ( !properties.Any( ) )
+        if ( !properties.Any ( ) )
         {
-            throw new ArgumentException( "Empty collection provided", nameof( properties ) );
+            throw new ArgumentException ( "Empty collection provided", nameof (properties) );
         }
 
-        return properties.Select( static p => p.SetString ).ToSpaceSeparatedSingleLineString( );
+        return properties.Select ( static p => p.SetString ).ToSpaceSeparatedSingleLineString ( );
     }
 }

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsProperty.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsProperty.cs
@@ -38,63 +38,63 @@ public readonly struct ZfsProperty<T> : IZfsProperty, IEquatable<int>, IEquatabl
     }
 
     // ReSharper disable once HeapView.ObjectAllocation
-    public readonly string InheritedFrom => IsLocal ? ZfsPropertySourceConstants.Local : Source[ 15.. ];
+    public string InheritedFrom => IsLocal ? ZfsPropertySourceConstants.Local : Source[ 15.. ];
 
     [JsonIgnore]
-    public readonly bool IsInherited => !IsLocal;
+    public bool IsInherited => !IsLocal;
 
     public T Value { get; init; }
 
     /// <inheritdoc />
-    public readonly bool Equals( bool other )
+    public bool Equals( bool other )
     {
         return Value is bool v && v == other;
     }
 
     /// <inheritdoc />
-    public readonly bool Equals( DateTimeOffset other )
+    public bool Equals( DateTimeOffset other )
     {
         return Value is DateTimeOffset v && v == other;
     }
 
     /// <inheritdoc />
-    public readonly bool Equals( int other )
+    public bool Equals( int other )
     {
         return Value is int v && v == other;
     }
 
     /// <inheritdoc />
-    public readonly bool Equals( string? other )
+    public bool Equals( string? other )
     {
         return Value is string v && v == other;
     }
 
     /// <inheritdoc />
-    public readonly bool Equals( ZfsProperty<bool> other )
+    public bool Equals( ZfsProperty<bool> other )
     {
         return Value is bool v && Name == other.Name && v == other.Value && IsLocal == other.IsLocal;
     }
 
     /// <inheritdoc />
-    public readonly bool Equals( ZfsProperty<DateTimeOffset> other )
+    public bool Equals( ZfsProperty<DateTimeOffset> other )
     {
         return Value is DateTimeOffset v && Name == other.Name && v == other.Value && IsLocal == other.IsLocal;
     }
 
     /// <inheritdoc />
-    public readonly bool Equals( ZfsProperty<int> other )
+    public bool Equals( ZfsProperty<int> other )
     {
         return Value is int v && Name == other.Name && v == other.Value && IsLocal == other.IsLocal;
     }
 
     /// <inheritdoc />
-    public readonly bool Equals( ZfsProperty<string> other )
+    public bool Equals( ZfsProperty<string> other )
     {
         return Value is string v && Name == other.Name && v == other.Value && IsLocal == other.IsLocal;
     }
 
     [JsonIgnore]
-    public readonly string Source => IsLocal switch
+    public string Source => IsLocal switch
     {
         true => ZfsPropertySourceConstants.Local,
         false when Owner is null => ZfsPropertySourceConstants.None,
@@ -110,7 +110,7 @@ public readonly struct ZfsProperty<T> : IZfsProperty, IEquatable<int>, IEquatabl
     ///     Gets a string representation of the Value property, in an appropriate form for its type
     /// </summary>
     [JsonIgnore]
-    public readonly string ValueString => Value switch
+    public string ValueString => Value switch
     {
         int intValue => intValue.ToString( ),
         string value => value,
@@ -120,7 +120,7 @@ public readonly struct ZfsProperty<T> : IZfsProperty, IEquatable<int>, IEquatabl
 
     [JsonIgnore]
     // ReSharper disable once HeapView.ObjectAllocation
-    public readonly string SetString => $"{Name}={ValueString}";
+    public string SetString => $"{Name}={ValueString}";
 
     public string Name { get; init; }
     public bool IsLocal { get; init; }
@@ -152,7 +152,7 @@ public readonly struct ZfsProperty<T> : IZfsProperty, IEquatable<int>, IEquatabl
     public static ZfsProperty<T> DefaultProperty( ) => new( );
 
     /// <inheritdoc />
-    public readonly override int GetHashCode( )
+    public override int GetHashCode( )
     {
         return HashCode.Combine( Value, Name, IsLocal );
     }

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsProperty.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsProperty.cs
@@ -1,12 +1,16 @@
-// LICENSE:
+#region MIT LICENSE
+
+// Copyright 2025 Brandon Thetford
 // 
-// Copyright 2023 Brandon Thetford
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+// See https://opensource.org/license/MIT/
+
+#endregion
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
@@ -20,88 +24,65 @@ using System.Runtime.CompilerServices;
 public readonly struct ZfsProperty<T> : IZfsProperty, IEquatable<int>, IEquatable<string>, IEquatable<bool>, IEquatable<DateTimeOffset>, IEquatable<ZfsProperty<int>>, IEquatable<ZfsProperty<bool>>, IEquatable<ZfsProperty<string>>, IEquatable<ZfsProperty<DateTimeOffset>> where T : notnull
 {
     // ReSharper disable once StaticMemberInGenericType
-    private static readonly Logger Logger = LogManager.GetCurrentClassLogger( );
+    private static readonly Logger Logger = LogManager.GetCurrentClassLogger ( );
 
     private ZfsProperty ( string name, in T value, bool isLocal = true )
     {
-        Name = name;
-        Value = value;
+        Name    = name;
+        Value   = value;
         IsLocal = isLocal;
     }
 
     public ZfsProperty ( ZfsRecord owner, string name, in T value, bool isLocal = true )
     {
-        Owner = owner;
-        Name = name;
-        Value = value;
+        Owner   = owner;
+        Name    = name;
+        Value   = value;
         IsLocal = isLocal;
     }
 
     // ReSharper disable once HeapView.ObjectAllocation
-    public string InheritedFrom => IsLocal ? ZfsPropertySourceConstants.Local : Source[ 15.. ];
+    public string InheritedFrom => IsLocal ? ZfsPropertySourceConstants.Local : Source [ 15.. ];
 
     [JsonIgnore]
     public bool IsInherited => !IsLocal;
 
     public T Value { get; init; }
 
-    /// <inheritdoc />
-    public bool Equals( bool other )
-    {
-        return Value is bool v && v == other;
-    }
+    /// <inheritdoc/>
+    public bool Equals ( bool other ) => Value is bool v && v == other;
 
-    /// <inheritdoc />
-    public bool Equals( DateTimeOffset other )
-    {
-        return Value is DateTimeOffset v && v == other;
-    }
+    /// <inheritdoc/>
+    public bool Equals ( DateTimeOffset other ) => Value is DateTimeOffset v && v == other;
 
-    /// <inheritdoc />
-    public bool Equals( int other )
-    {
-        return Value is int v && v == other;
-    }
+    /// <inheritdoc/>
+    public bool Equals ( int other ) => Value is int v && v == other;
 
-    /// <inheritdoc />
-    public bool Equals( string? other )
-    {
-        return Value is string v && v == other;
-    }
+    /// <inheritdoc/>
+    public bool Equals ( string? other ) => Value is string v && v == other;
 
-    /// <inheritdoc />
-    public bool Equals( ZfsProperty<bool> other )
-    {
-        return Value is bool v && Name == other.Name && v == other.Value && IsLocal == other.IsLocal;
-    }
+    /// <inheritdoc/>
+    public bool Equals ( ZfsProperty<bool> other ) => Value is bool v && Name == other.Name && v == other.Value && IsLocal == other.IsLocal;
 
-    /// <inheritdoc />
-    public bool Equals( ZfsProperty<DateTimeOffset> other )
-    {
-        return Value is DateTimeOffset v && Name == other.Name && v == other.Value && IsLocal == other.IsLocal;
-    }
+    /// <inheritdoc/>
+    public bool Equals ( ZfsProperty<DateTimeOffset> other ) => Value is DateTimeOffset v && Name == other.Name && v == other.Value && IsLocal == other.IsLocal;
 
-    /// <inheritdoc />
-    public bool Equals( ZfsProperty<int> other )
-    {
-        return Value is int v && Name == other.Name && v == other.Value && IsLocal == other.IsLocal;
-    }
+    /// <inheritdoc/>
+    public bool Equals ( ZfsProperty<int> other ) => Value is int v && Name == other.Name && v == other.Value && IsLocal == other.IsLocal;
 
-    /// <inheritdoc />
-    public bool Equals( ZfsProperty<string> other )
-    {
-        return Value is string v && Name == other.Name && v == other.Value && IsLocal == other.IsLocal;
-    }
+    /// <inheritdoc/>
+    public bool Equals ( ZfsProperty<string> other ) => Value is string v && Name == other.Name && v == other.Value && IsLocal == other.IsLocal;
 
     [JsonIgnore]
     public string Source => IsLocal switch
-    {
-        true => ZfsPropertySourceConstants.Local,
-        false when Owner is null => ZfsPropertySourceConstants.None,
-        // ReSharper disable once HeapView.ObjectAllocation
-        false when Owner.ParentDataset[ Name ].IsLocal => $"inherited from {Owner.ParentDataset.Name}",
-        false => Owner.ParentDataset[ Name ].Source
-    };
+                            {
+                                true                     => ZfsPropertySourceConstants.Local,
+                                false when Owner is null => ZfsPropertySourceConstants.None,
+
+                                // ReSharper disable once HeapView.ObjectAllocation
+                                false when Owner.ParentDataset [ Name ].IsLocal => $"inherited from {Owner.ParentDataset.Name}",
+                                false                                           => Owner.ParentDataset [ Name ].Source
+                            };
 
     [JsonIgnore]
     public ZfsRecord? Owner { get; init; }
@@ -111,154 +92,109 @@ public readonly struct ZfsProperty<T> : IZfsProperty, IEquatable<int>, IEquatabl
     /// </summary>
     [JsonIgnore]
     public string ValueString => Value switch
-    {
-        int intValue => intValue.ToString( ),
-        string value => value,
-        bool boolValue => boolValue.ToString( ).ToLowerInvariant( ),
-        DateTimeOffset dtoValue => dtoValue.ToString( "O" )
-    };
+                                 {
+                                     int intValue            => intValue.ToString ( ),
+                                     string value            => value,
+                                     bool boolValue          => boolValue.ToString ( ).ToLowerInvariant ( ),
+                                     DateTimeOffset dtoValue => dtoValue.ToString ( "O" )
+                                 };
 
     [JsonIgnore]
+
     // ReSharper disable once HeapView.ObjectAllocation
     public string SetString => $"{Name}={ValueString}";
 
-    public string Name { get; init; }
-    public bool IsLocal { get; init; }
+    public string Name    { get; init; }
+    public bool   IsLocal { get; init; }
 
-    public static ZfsProperty<bool> CreateWithoutParent( string name, in bool value, bool isLocal = true )
+    public static ZfsProperty<bool> CreateWithoutParent ( string name, in bool value, bool isLocal = true )
     {
-        Logger.Trace( "Creating ZfsProperty<bool> {0} without parent dataset", name );
-        return new( name, in value, isLocal );
+        Logger.Trace ( "Creating ZfsProperty<bool> {0} without parent dataset", name );
+
+        return new ( name, in value, isLocal );
     }
 
-    public static ZfsProperty<int> CreateWithoutParent( string name, in int value, bool isLocal = true )
+    public static ZfsProperty<int> CreateWithoutParent ( string name, in int value, bool isLocal = true )
     {
-        Logger.Trace( "Creating ZfsProperty<int> {0} without parent dataset", name );
-        return new( name, in value, isLocal );
+        Logger.Trace ( "Creating ZfsProperty<int> {0} without parent dataset", name );
+
+        return new ( name, in value, isLocal );
     }
 
-    public static ZfsProperty<string> CreateWithoutParent( string name, string value, bool isLocal = true )
+    public static ZfsProperty<string> CreateWithoutParent ( string name, string value, bool isLocal = true )
     {
-        Logger.Trace( "Creating ZfsProperty<string> {0} without parent dataset", name );
-        return new( name, in value, isLocal );
+        Logger.Trace ( "Creating ZfsProperty<string> {0} without parent dataset", name );
+
+        return new ( name, in value, isLocal );
     }
 
-    public static ZfsProperty<DateTimeOffset> CreateWithoutParent( string name, in DateTimeOffset value, bool isLocal = true )
+    public static ZfsProperty<DateTimeOffset> CreateWithoutParent ( string name, in DateTimeOffset value, bool isLocal = true )
     {
-        Logger.Trace( "Creating ZfsProperty<DateTimeOffset> {0} without parent dataset", name );
-        return new( name, in value, isLocal );
+        Logger.Trace ( "Creating ZfsProperty<DateTimeOffset> {0} without parent dataset", name );
+
+        return new ( name, in value, isLocal );
     }
 
-    public static ZfsProperty<T> DefaultProperty( ) => new( );
+    public static ZfsProperty<T> DefaultProperty ( ) => new ( );
 
-    /// <inheritdoc />
-    public override int GetHashCode( )
-    {
-        return HashCode.Combine( Value, Name, IsLocal );
-    }
+    /// <inheritdoc/>
+    public override int GetHashCode ( ) => HashCode.Combine ( Value, Name, IsLocal );
 
-    public static bool operator ==( ZfsProperty<T> left, bool right )
-    {
-        return left.Equals( right );
-    }
+    public static bool operator == ( ZfsProperty<T> left, bool right ) => left.Equals ( right );
 
-    public static bool operator ==( ZfsProperty<T> left, int right )
-    {
-        return left.Equals( right );
-    }
+    public static bool operator == ( ZfsProperty<T> left, int right ) => left.Equals ( right );
 
-    public static bool operator ==( ZfsProperty<T> left, string right )
-    {
-        return left.Equals( right );
-    }
+    public static bool operator == ( ZfsProperty<T> left, string right ) => left.Equals ( right );
 
-    public static bool operator ==( ZfsProperty<T> left, DateTimeOffset right )
-    {
-        return left.Equals( right );
-    }
+    public static bool operator == ( ZfsProperty<T> left, DateTimeOffset right ) => left.Equals ( right );
 
-    public static bool operator ==( ZfsProperty<T> left, ZfsProperty<bool> right )
-    {
-        return left.Equals( right );
-    }
+    public static bool operator == ( ZfsProperty<T> left, ZfsProperty<bool> right ) => left.Equals ( right );
 
-    public static bool operator ==( ZfsProperty<T> left, ZfsProperty<int> right )
-    {
-        return left.Equals( right );
-    }
+    public static bool operator == ( ZfsProperty<T> left, ZfsProperty<int> right ) => left.Equals ( right );
 
-    public static bool operator ==( ZfsProperty<T> left, ZfsProperty<string> right )
-    {
-        return left.Equals( right );
-    }
+    public static bool operator == ( ZfsProperty<T> left, ZfsProperty<string> right ) => left.Equals ( right );
 
-    public static bool operator ==( ZfsProperty<T> left, ZfsProperty<DateTimeOffset> right )
-    {
-        return left.Equals( right );
-    }
+    public static bool operator == ( ZfsProperty<T> left, ZfsProperty<DateTimeOffset> right ) => left.Equals ( right );
 
-    public static bool operator !=( ZfsProperty<T> left, bool right )
-    {
-        return !left.Equals( right );
-    }
+    public static bool operator != ( ZfsProperty<T> left, bool right ) => !left.Equals ( right );
 
-    public static bool operator !=( ZfsProperty<T> left, int right )
-    {
-        return !left.Equals( right );
-    }
+    public static bool operator != ( ZfsProperty<T> left, int right ) => !left.Equals ( right );
 
-    public static bool operator !=( ZfsProperty<T> left, string right )
-    {
-        return !left.Equals( right );
-    }
+    public static bool operator != ( ZfsProperty<T> left, string right ) => !left.Equals ( right );
 
-    public static bool operator !=( ZfsProperty<T> left, DateTimeOffset right )
-    {
-        return !left.Equals( right );
-    }
+    public static bool operator != ( ZfsProperty<T> left, DateTimeOffset right ) => !left.Equals ( right );
 
-    public static bool operator !=( ZfsProperty<T> left, ZfsProperty<bool> right )
-    {
-        return !left.Equals( right );
-    }
+    public static bool operator != ( ZfsProperty<T> left, ZfsProperty<bool> right ) => !left.Equals ( right );
 
-    public static bool operator !=( ZfsProperty<T> left, ZfsProperty<int> right )
-    {
-        return !left.Equals( right );
-    }
+    public static bool operator != ( ZfsProperty<T> left, ZfsProperty<int> right ) => !left.Equals ( right );
 
-    public static bool operator !=( ZfsProperty<T> left, ZfsProperty<string> right )
-    {
-        return !left.Equals( right );
-    }
+    public static bool operator != ( ZfsProperty<T> left, ZfsProperty<string> right ) => !left.Equals ( right );
 
-    public static bool operator !=( ZfsProperty<T> left, ZfsProperty<DateTimeOffset> right )
-    {
-        return !left.Equals( right );
-    }
+    public static bool operator != ( ZfsProperty<T> left, ZfsProperty<DateTimeOffset> right ) => !left.Equals ( right );
 
     /// <summary>
-    ///     Attempts to parse a <see cref="RawProperty" /> as its <see cref="ZfsProperty{T}" /> (<see langword="bool" />) equivalent
+    ///     Attempts to parse a <see cref="RawProperty"/> as its <see cref="ZfsProperty{T}"/> (<see langword="bool"/>) equivalent
     /// </summary>
-    /// <param name="input">The <see cref="RawProperty" /> to parse</param>
+    /// <param name="input">The <see cref="RawProperty"/> to parse</param>
     /// <param name="property">
-    ///     The parsed <see cref="ZfsProperty{T}" /> (<see langword="bool" />), if successful
+    ///     The parsed <see cref="ZfsProperty{T}"/> (<see langword="bool"/>), if successful
     /// </param>
     /// <returns>
-    ///     <see langword="true" /> if <paramref name="input" /> was parsed successfully; otherwise <see langword="false" />
+    ///     <see langword="true"/> if <paramref name="input"/> was parsed successfully; otherwise <see langword="false"/>
     /// </returns>
     /// <remarks>
-    ///     <paramref name="property" /> is never null when this method returns <see langword="true" />; otherwise,
-    ///     <paramref name="property" /> is always <see langword="null" />
+    ///     <paramref name="property"/> is never null when this method returns <see langword="true"/>; otherwise,
+    ///     <paramref name="property"/> is always <see langword="null"/>
     /// </remarks>
-    public static bool TryParse( RawProperty input, [NotNullWhen( true )] out ZfsProperty<bool>? property )
+    public static bool TryParse ( RawProperty input, [NotNullWhen ( true )] out ZfsProperty<bool>? property )
     {
         property = null;
 
         // ReSharper disable once InvertIf
-        if ( bool.TryParse( input.Value, out bool result ) )
+        if ( bool.TryParse ( input.Value, out bool result ) )
         {
-            property = ZfsProperty<bool>.CreateWithoutParent( input.Name, result, input.Source == ZfsPropertySourceConstants.Local );
+            property = ZfsProperty<bool>.CreateWithoutParent ( input.Name, result, input.Source == ZfsPropertySourceConstants.Local );
+
             return true;
         }
 
@@ -266,55 +202,59 @@ public readonly struct ZfsProperty<T> : IZfsProperty, IEquatable<int>, IEquatabl
     }
 
     /// <summary>
-    ///     Attempts to parse a <see cref="RawProperty" /> as its <see cref="ZfsProperty{T}" /> (<see langword="int" />) equivalent
+    ///     Attempts to parse a <see cref="RawProperty"/> as its <see cref="ZfsProperty{T}"/> (<see langword="int"/>) equivalent
     /// </summary>
-    /// <param name="input">The <see cref="RawProperty" /> to parse</param>
+    /// <param name="input">The <see cref="RawProperty"/> to parse</param>
     /// <param name="property">
-    ///     The parsed <see cref="ZfsProperty{T}" /> (<see langword="int" />), if successful
+    ///     The parsed <see cref="ZfsProperty{T}"/> (<see langword="int"/>), if successful
     /// </param>
     /// <returns>
-    ///     <see langword="true" /> if <paramref name="input" /> was parsed successfully; otherwise <see langword="false" />
+    ///     <see langword="true"/> if <paramref name="input"/> was parsed successfully; otherwise <see langword="false"/>
     /// </returns>
     /// <remarks>
-    ///     <paramref name="property" /> is never null when this method returns <see langword="true" />; otherwise,
-    ///     <paramref name="property" /> is always <see langword="null" />
+    ///     <paramref name="property"/> is never null when this method returns <see langword="true"/>; otherwise,
+    ///     <paramref name="property"/> is always <see langword="null"/>
     /// </remarks>
-    public static bool TryParse( RawProperty input, [NotNullWhen( true )] out ZfsProperty<int>? property )
+    public static bool TryParse ( RawProperty input, [NotNullWhen ( true )] out ZfsProperty<int>? property )
     {
-        if ( int.TryParse( input.Value, out int result ) )
+        if ( int.TryParse ( input.Value, out int result ) )
         {
-            property = ZfsProperty<int>.CreateWithoutParent( input.Name, result, input.Source == ZfsPropertySourceConstants.Local );
+            property = ZfsProperty<int>.CreateWithoutParent ( input.Name, result, input.Source == ZfsPropertySourceConstants.Local );
+
             return true;
         }
 
         property = null;
+
         return false;
     }
 
     /// <summary>
-    ///     Attempts to parse a <see cref="RawProperty" /> as its <see cref="ZfsProperty{T}" /> (<see cref="DateTimeOffset" />)
+    ///     Attempts to parse a <see cref="RawProperty"/> as its <see cref="ZfsProperty{T}"/> (<see cref="DateTimeOffset"/>)
     ///     equivalent
     /// </summary>
-    /// <param name="input">The <see cref="RawProperty" /> to parse</param>
+    /// <param name="input">The <see cref="RawProperty"/> to parse</param>
     /// <param name="property">
-    ///     The parsed <see cref="ZfsProperty{T}" /> (<see cref="DateTimeOffset" />), if successful
+    ///     The parsed <see cref="ZfsProperty{T}"/> (<see cref="DateTimeOffset"/>), if successful
     /// </param>
     /// <returns>
-    ///     <see langword="true" /> if <paramref name="input" /> was parsed successfully; otherwise <see langword="false" />
+    ///     <see langword="true"/> if <paramref name="input"/> was parsed successfully; otherwise <see langword="false"/>
     /// </returns>
     /// <remarks>
-    ///     <paramref name="property" /> is never null when this method returns <see langword="true" />; otherwise,
-    ///     <paramref name="property" /> is always <see langword="null" />
+    ///     <paramref name="property"/> is never null when this method returns <see langword="true"/>; otherwise,
+    ///     <paramref name="property"/> is always <see langword="null"/>
     /// </remarks>
-    public static bool TryParse( RawProperty input, [NotNullWhen( true )] out ZfsProperty<DateTimeOffset>? property )
+    public static bool TryParse ( RawProperty input, [NotNullWhen ( true )] out ZfsProperty<DateTimeOffset>? property )
     {
-        if ( DateTimeOffset.TryParse( input.Value, out DateTimeOffset result ) )
+        if ( DateTimeOffset.TryParse ( input.Value, out DateTimeOffset result ) )
         {
-            property = ZfsProperty<DateTimeOffset>.CreateWithoutParent( input.Name, result, input.Source == ZfsPropertySourceConstants.Local );
+            property = ZfsProperty<DateTimeOffset>.CreateWithoutParent ( input.Name, result, input.Source == ZfsPropertySourceConstants.Local );
+
             return true;
         }
 
         property = null;
+
         return false;
     }
 
@@ -345,7 +285,7 @@ public readonly struct ZfsProperty<T> : IZfsProperty, IEquatable<int>, IEquatabl
     )
     {
         bytesAvailable = 0;
-        bytesUsed = 0;
+        bytesUsed      = 0;
         Unsafe.SkipInit ( out enabled );
         Unsafe.SkipInit ( out takeSnapshots );
         Unsafe.SkipInit ( out pruneSnapshots );

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsProperty.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsProperty.cs
@@ -17,7 +17,7 @@ namespace SnapsInAZfs.Interop.Zfs.ZfsTypes;
 
 using System.Runtime.CompilerServices;
 
-public struct ZfsProperty<T> : IZfsProperty, IEquatable<int>, IEquatable<string>, IEquatable<bool>, IEquatable<DateTimeOffset>, IEquatable<ZfsProperty<int>>, IEquatable<ZfsProperty<bool>>, IEquatable<ZfsProperty<string>>, IEquatable<ZfsProperty<DateTimeOffset>> where T : notnull
+public readonly struct ZfsProperty<T> : IZfsProperty, IEquatable<int>, IEquatable<string>, IEquatable<bool>, IEquatable<DateTimeOffset>, IEquatable<ZfsProperty<int>>, IEquatable<ZfsProperty<bool>>, IEquatable<ZfsProperty<string>>, IEquatable<ZfsProperty<DateTimeOffset>> where T : notnull
 {
     // ReSharper disable once StaticMemberInGenericType
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger( );
@@ -104,7 +104,7 @@ public struct ZfsProperty<T> : IZfsProperty, IEquatable<int>, IEquatable<string>
     };
 
     [JsonIgnore]
-    public ZfsRecord? Owner { get; set; }
+    public ZfsRecord? Owner { get; init; }
 
     /// <summary>
     ///     Gets a string representation of the Value property, in an appropriate form for its type

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsProperty.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsProperty.cs
@@ -24,7 +24,7 @@ using System.Runtime.CompilerServices;
 public readonly struct ZfsProperty<T> : IZfsProperty, IEquatable<int>, IEquatable<string>, IEquatable<bool>, IEquatable<DateTimeOffset>, IEquatable<ZfsProperty<int>>, IEquatable<ZfsProperty<bool>>, IEquatable<ZfsProperty<string>>, IEquatable<ZfsProperty<DateTimeOffset>> where T : notnull
 {
     // ReSharper disable once StaticMemberInGenericType
-    private static readonly Logger Logger = LogManager.GetCurrentClassLogger ( );
+    private static readonly Logger Logger = LogManager.GetLogger ( $"{StringConstants.ZfsTypesNamespace}.{nameof (ZfsProperty<T>)}" )!;
 
     private ZfsProperty ( string name, in T value, bool isLocal = true )
     {

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsProperty.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsProperty.cs
@@ -13,14 +13,13 @@
 #endregion
 
 using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Text.Json.Serialization;
-using NLog;
 using SnapsInAZfs.Interop.Zfs.ZfsCommandRunner;
 
 namespace SnapsInAZfs.Interop.Zfs.ZfsTypes;
 
-using System.Numerics;
-using System.Runtime.CompilerServices;
 
 public readonly struct ZfsProperty<T> : IZfsProperty, IEquatable<int>, IEquatable<string>, IEquatable<bool>, IEquatable<DateTimeOffset>, IEquatable<ZfsProperty<T>>, IEqualityOperators<ZfsProperty<T>, ZfsProperty<T>, bool> where T : notnull
 {

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsPropertyNames.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsPropertyNames.cs
@@ -1,37 +1,41 @@
-// LICENSE:
+#region MIT LICENSE
+
+// Copyright 2025 Brandon Thetford
 // 
-// Copyright 2023 Brandon Thetford
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+// See https://opensource.org/license/MIT/
+
+#endregion
 
 namespace SnapsInAZfs.Interop.Zfs.ZfsTypes;
 
 public static class ZfsPropertyNames
 {
-    public const string DatasetLastDailySnapshotTimestampPropertyName = $"{SiazNamespace}:lastdailysnapshottimestamp";
-    public const string DatasetLastFrequentSnapshotTimestampPropertyName = $"{SiazNamespace}:lastfrequentsnapshottimestamp";
-    public const string DatasetLastHourlySnapshotTimestampPropertyName = $"{SiazNamespace}:lasthourlysnapshottimestamp";
-    public const string DatasetLastMonthlySnapshotTimestampPropertyName = $"{SiazNamespace}:lastmonthlysnapshottimestamp";
-    public const string DatasetLastWeeklySnapshotTimestampPropertyName = $"{SiazNamespace}:lastweeklysnapshottimestamp";
-    public const string DatasetLastYearlySnapshotTimestampPropertyName = $"{SiazNamespace}:lastyearlysnapshottimestamp";
-    public const string EnabledPropertyName = $"{SiazNamespace}:enabled";
-    public const string PruneSnapshotsPropertyName = $"{SiazNamespace}:prunesnapshots";
-    public const string RecursionPropertyName = $"{SiazNamespace}:recursion";
-    public const string SnapshotPeriodPropertyName = $"{SiazNamespace}:snapshot:period";
-    public const string SnapshotRetentionDailyPropertyName = $"{SiazNamespace}:retention:daily";
-    public const string SnapshotRetentionFrequentPropertyName = $"{SiazNamespace}:retention:frequent";
-    public const string SnapshotRetentionHourlyPropertyName = $"{SiazNamespace}:retention:hourly";
-    public const string SnapshotRetentionMonthlyPropertyName = $"{SiazNamespace}:retention:monthly";
-    public const string SnapshotRetentionPruneDeferralPropertyName = $"{SiazNamespace}:retention:prunedeferral";
-    public const string SnapshotRetentionWeeklyPropertyName = $"{SiazNamespace}:retention:weekly";
-    public const string SnapshotRetentionYearlyPropertyName = $"{SiazNamespace}:retention:yearly";
-    public const string SnapshotTimestampPropertyName = $"{SiazNamespace}:snapshot:timestamp";
-    public const string SourceSystem = $"{SiazNamespace}:sourcesystem";
-    public const string TakeSnapshotsPropertyName = $"{SiazNamespace}:takesnapshots";
-    public const string TemplatePropertyName = $"{SiazNamespace}:template";
-    internal const string SiazNamespace = "snapsinazfs.com";
+    public const   string DatasetLastDailySnapshotTimestampPropertyName    = $"{SiazZfsPropNamespace}:lastdailysnapshottimestamp";
+    public const   string DatasetLastFrequentSnapshotTimestampPropertyName = $"{SiazZfsPropNamespace}:lastfrequentsnapshottimestamp";
+    public const   string DatasetLastHourlySnapshotTimestampPropertyName   = $"{SiazZfsPropNamespace}:lasthourlysnapshottimestamp";
+    public const   string DatasetLastMonthlySnapshotTimestampPropertyName  = $"{SiazZfsPropNamespace}:lastmonthlysnapshottimestamp";
+    public const   string DatasetLastWeeklySnapshotTimestampPropertyName   = $"{SiazZfsPropNamespace}:lastweeklysnapshottimestamp";
+    public const   string DatasetLastYearlySnapshotTimestampPropertyName   = $"{SiazZfsPropNamespace}:lastyearlysnapshottimestamp";
+    public const   string EnabledPropertyName                              = $"{SiazZfsPropNamespace}:enabled";
+    public const   string PruneSnapshotsPropertyName                       = $"{SiazZfsPropNamespace}:prunesnapshots";
+    public const   string RecursionPropertyName                            = $"{SiazZfsPropNamespace}:recursion";
+    public const   string SnapshotPeriodPropertyName                       = $"{SiazZfsPropNamespace}:snapshot:period";
+    public const   string SnapshotRetentionDailyPropertyName               = $"{SiazZfsPropNamespace}:retention:daily";
+    public const   string SnapshotRetentionFrequentPropertyName            = $"{SiazZfsPropNamespace}:retention:frequent";
+    public const   string SnapshotRetentionHourlyPropertyName              = $"{SiazZfsPropNamespace}:retention:hourly";
+    public const   string SnapshotRetentionMonthlyPropertyName             = $"{SiazZfsPropNamespace}:retention:monthly";
+    public const   string SnapshotRetentionPruneDeferralPropertyName       = $"{SiazZfsPropNamespace}:retention:prunedeferral";
+    public const   string SnapshotRetentionWeeklyPropertyName              = $"{SiazZfsPropNamespace}:retention:weekly";
+    public const   string SnapshotRetentionYearlyPropertyName              = $"{SiazZfsPropNamespace}:retention:yearly";
+    public const   string SnapshotTimestampPropertyName                    = $"{SiazZfsPropNamespace}:snapshot:timestamp";
+    public const   string SourceSystem                                     = $"{SiazZfsPropNamespace}:sourcesystem";
+    public const   string TakeSnapshotsPropertyName                        = $"{SiazZfsPropNamespace}:takesnapshots";
+    public const   string TemplatePropertyName                             = $"{SiazZfsPropNamespace}:template";
+    internal const string SiazZfsPropNamespace                             = "snapsinazfs.com";
 }

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsPropertyValueConstants.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsPropertyValueConstants.cs
@@ -1,12 +1,12 @@
-﻿#region MIT LICENSE
+#region MIT LICENSE
 
-// Copyright 2023 Brandon Thetford
+// Copyright 2025 Brandon Thetford
 // 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // 
 // See https://opensource.org/license/MIT/
 
@@ -14,25 +14,30 @@
 
 namespace SnapsInAZfs.Interop.Zfs.ZfsTypes;
 
+using System.Collections.Frozen;
+
 public static class ZfsPropertyValueConstants
 {
-    public const string Default = "default";
-    public const string FileSystem = "filesystem";
-    public const string None = "-";
-    public const string Snapshot = "snapshot";
-    public const string SnapsInAZfs = "siaz";
+    public const string Default              = "default";
+    public const string FileSystem           = "filesystem";
+    public const string None                 = "-";
+    public const string Snapshot             = "snapshot";
+    public const string SnapsInAZfs          = "siaz";
     public const string StandaloneSiazSystem = "StandaloneSiazSystem";
-    public const string Volume = "volume";
-    public const string ZfsRecursion = "zfs";
+    public const string Volume               = "volume";
+    public const string ZfsRecursion         = "zfs";
 
-    public static readonly Dictionary<string, (int Min, int Max)> IntPropertyRanges = new( )
-    {
-        { ZfsPropertyNames.SnapshotRetentionFrequentPropertyName, new( 0, int.MaxValue ) },
-        { ZfsPropertyNames.SnapshotRetentionHourlyPropertyName, new( 0, int.MaxValue ) },
-        { ZfsPropertyNames.SnapshotRetentionDailyPropertyName, new( 0, int.MaxValue ) },
-        { ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName, new( 0, int.MaxValue ) },
-        { ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName, new( 0, int.MaxValue ) },
-        { ZfsPropertyNames.SnapshotRetentionYearlyPropertyName, new( 0, int.MaxValue ) },
-        { ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, new( 0, 100 ) }
-    };
+    private static readonly (int, int) ZeroToIntMax = ( 0, int.MaxValue );
+
+    public static readonly FrozenDictionary<string, (int Min, int Max)> IntPropertyRanges =
+        new Dictionary<string, (int Min, int Max)>
+        {
+            { ZfsPropertyNames.SnapshotRetentionFrequentPropertyName, ZeroToIntMax },
+            { ZfsPropertyNames.SnapshotRetentionHourlyPropertyName, ZeroToIntMax },
+            { ZfsPropertyNames.SnapshotRetentionDailyPropertyName, ZeroToIntMax },
+            { ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName, ZeroToIntMax },
+            { ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName, ZeroToIntMax },
+            { ZfsPropertyNames.SnapshotRetentionYearlyPropertyName, ZeroToIntMax },
+            { ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, new ( 0, 100 ) }
+        }.ToFrozenDictionary ( );
 }

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
@@ -100,6 +100,7 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
         }
     }
 
+    /// <summary>(Protected) Creates a new instance of a <see cref="ZfsRecord"/> from all supplied properties.</summary>
     /// <exception cref="ArgumentException">sourceSystem must have a non-null, non-whitespace-only Value</exception>
     protected ZfsRecord (
         string                         name,
@@ -314,6 +315,10 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
      && SnapshotCount                         == other.SnapshotCount
      && ChildDatasetCount                     == other.ChildDatasetCount;
 
+    /// <summary>
+    ///     Adds a <see cref="ZfsRecord"/> as an immediate descendant of the current <see cref="ZfsRecord"/> and subscribes the
+    ///     descendant to events published by the current <see cref="ZfsRecord"/>.
+    /// </summary>
     /// <exception cref="ArgumentException">
     ///     If the <see cref="ParentDataset"/> property of <paramref name="childDataset"/> does not reference this
     ///     <see cref="ZfsRecord"/> instance.
@@ -329,6 +334,13 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
         _childDatasets [ childDataset.Name ] = childDataset;
     }
 
+    /// <summary>
+    ///     Adds a <see cref="Snapshot"/> as an immediate descendant of the current <see cref="ZfsRecord"/> and subscribes the
+    ///     descendant to events published by the current <see cref="ZfsRecord"/>.
+    /// </summary>
+    /// <returns>
+    ///     The same <see cref="Snapshot"/> reference that was supplied to this method in <paramref name="snap"/>.
+    /// </returns>
     public Snapshot AddSnapshot ( Snapshot snap )
     {
         Logger.Trace ( "Adding snapshot {0} to {1} {2}", snap.Name, Kind, Name );
@@ -452,6 +464,10 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
         return snap;
     }
 
+    /// <summary>
+    ///     Convenience method that creates a descendant <see cref="ZfsRecord"/> from the provided parameters and calls
+    ///     <see cref="AddDataset"/> to add it to the current <see cref="ZfsRecord"/>.
+    /// </summary>
     /// <exception cref="ArgumentNullException">
     ///     <paramref name="sourceSystem"/> is <see langword="null"/>, empty, or only whitespace
     /// </exception>
@@ -502,6 +518,9 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
         return newDs;
     }
 
+    /// <summary>
+    ///     Factory method that creates a new <see cref="ZfsRecord"/> via the protected constructor.
+    /// </summary>
     /// <exception cref="ArgumentException">sourceSystem must have a non-null, non-whitespace-only Value</exception>
     public static ZfsRecord CreateInstanceFromAllProperties (
         string                         name,
@@ -1046,6 +1065,13 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
         return Snapshots [ snapshot.Period.Value.ToSnapshotPeriodKind ( ) ].TryRemove ( snapshot.Name, out _ );
     }
 
+    /// <summary>
+    ///     Validates a supplied <see cref="String"/> value against naming rules for ZFS objects supported by <see cref="ZfsRecord"/>.
+    /// </summary>
+    /// <remarks>
+    ///     <paramref name="name"/> is validated as non-null, non-whitespace, no longer than 255 codepoints, and matching a
+    ///     <see cref="Regex"/> according to the supplied <paramref name="kind"/>.
+    /// </remarks>
     /// <exception cref="ArgumentNullException">
     ///     name must be a non-null, non-empty, non-whitespace string <paramref name="name"/>
     /// </exception>

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
@@ -19,7 +19,6 @@ using System.Globalization;
 using System.Numerics;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
-using NLog;
 using SnapsInAZfs.Interop.Zfs.ZfsTypes.Validation;
 
 namespace SnapsInAZfs.Interop.Zfs.ZfsTypes;

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
@@ -1,12 +1,16 @@
-// LICENSE:
+#region MIT LICENSE
+
+// Copyright 2025 Brandon Thetford
 // 
-// Copyright 2023 Brandon Thetford
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+// See https://opensource.org/license/MIT/
+
+#endregion
 
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
@@ -15,216 +19,246 @@ using System.Globalization;
 using System.Numerics;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
-using JetBrains.Annotations;
 using NLog;
 using SnapsInAZfs.Interop.Zfs.ZfsTypes.Validation;
-using SnapsInAZfs.Settings.Settings;
 
 namespace SnapsInAZfs.Interop.Zfs.ZfsTypes;
 
 public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<ZfsRecord, ZfsRecord, bool>
 {
-    private static readonly Logger Logger = LogManager.GetCurrentClassLogger( );
+    private static readonly Logger Logger = LogManager.GetLogger ( $"{StringConstants.ZfsTypesNamespace}.{nameof (ZfsRecord)}" )!;
 
+    /// <summary>
+    ///     Represents a node in the ZFS hierarchy.
+    /// </summary>
     /// <exception cref="ArgumentNullException">
-    ///     <paramref name="sourceSystem" /> is <see langword="null" />, empty, or only whitespace
+    ///     <paramref name="sourceSystem"/> is <see langword="null"/>, empty, or only whitespace
     /// </exception>
-    public ZfsRecord( string Name, string Kind, string sourceSystem = "", bool inheritProperties = true, ZfsRecord? parent = null )
+    public ZfsRecord ( string Name, string Kind, string sourceSystem = "", bool inheritProperties = true, ZfsRecord? parent = null )
     {
-        if ( string.IsNullOrWhiteSpace( sourceSystem ) )
+        if ( string.IsNullOrWhiteSpace ( sourceSystem ) )
         {
-            throw new ArgumentNullException( nameof( sourceSystem ) );
+            throw new ArgumentNullException ( nameof (sourceSystem) );
         }
 
-        this.Name = Name;
-        IsPoolRoot = parent is null;
+        this.Name     = Name;
+        IsPoolRoot    = parent is null;
         ParentDataset = parent ?? this;
-        this.Kind = Kind;
+        this.Kind     = Kind;
+
         NameValidatorRegex = Kind switch
-        {
-            ZfsPropertyValueConstants.FileSystem => ZfsIdentifierRegexes.DatasetNameRegex( ),
-            ZfsPropertyValueConstants.Volume => ZfsIdentifierRegexes.DatasetNameRegex( ),
-            ZfsPropertyValueConstants.Snapshot => ZfsIdentifierRegexes.SnapshotNameRegex( ),
-            _ => throw new InvalidOperationException( "Unknown type of object specified for ZfsIdentifierValidator." )
-        };
+                             {
+                                 ZfsPropertyValueConstants.FileSystem => ZfsIdentifierRegexes.DatasetNameRegex ( ),
+                                 ZfsPropertyValueConstants.Volume     => ZfsIdentifierRegexes.DatasetNameRegex ( ),
+                                 ZfsPropertyValueConstants.Snapshot   => ZfsIdentifierRegexes.SnapshotNameRegex ( ),
+                                 _                                    => throw new InvalidOperationException ( "Unknown type of object specified for ZfsIdentifierValidator." )
+                             };
+
         if ( parent is { } && inheritProperties )
         {
-            _enabled = parent.Enabled with { IsLocal = false, Owner = this };
-            _lastDailySnapshotTimestamp = parent.LastDailySnapshotTimestamp with { Value = DateTimeOffset.UnixEpoch, IsLocal = true, Owner = this };
-            _lastFrequentSnapshotTimestamp = parent.LastFrequentSnapshotTimestamp with { Value = DateTimeOffset.UnixEpoch, IsLocal = true, Owner = this };
-            _lastHourlySnapshotTimestamp = parent.LastHourlySnapshotTimestamp with { Value = DateTimeOffset.UnixEpoch, IsLocal = true, Owner = this };
-            _lastMonthlySnapshotTimestamp = parent.LastMonthlySnapshotTimestamp with { Value = DateTimeOffset.UnixEpoch, IsLocal = true, Owner = this };
-            _lastWeeklySnapshotTimestamp = parent.LastWeeklySnapshotTimestamp with { Value = DateTimeOffset.UnixEpoch, IsLocal = true, Owner = this };
-            _lastYearlySnapshotTimestamp = parent.LastYearlySnapshotTimestamp with { Value = DateTimeOffset.UnixEpoch, IsLocal = true, Owner = this };
-            _pruneSnapshotsField = parent.PruneSnapshots with { IsLocal = false, Owner = this };
-            _recursion = parent.Recursion with { IsLocal = false, Owner = this };
-            _snapshotRetentionDaily = parent.SnapshotRetentionDaily with { IsLocal = false, Owner = this };
-            _snapshotRetentionFrequent = parent.SnapshotRetentionFrequent with { IsLocal = false, Owner = this };
-            _snapshotRetentionHourly = parent.SnapshotRetentionHourly with { IsLocal = false, Owner = this };
-            _snapshotRetentionMonthly = parent.SnapshotRetentionMonthly with { IsLocal = false, Owner = this };
+            _enabled                        = parent.Enabled with { IsLocal = false, Owner = this };
+            _lastDailySnapshotTimestamp     = parent.LastDailySnapshotTimestamp with { Value = DateTimeOffset.UnixEpoch, IsLocal = true, Owner = this };
+            _lastFrequentSnapshotTimestamp  = parent.LastFrequentSnapshotTimestamp with { Value = DateTimeOffset.UnixEpoch, IsLocal = true, Owner = this };
+            _lastHourlySnapshotTimestamp    = parent.LastHourlySnapshotTimestamp with { Value = DateTimeOffset.UnixEpoch, IsLocal = true, Owner = this };
+            _lastMonthlySnapshotTimestamp   = parent.LastMonthlySnapshotTimestamp with { Value = DateTimeOffset.UnixEpoch, IsLocal = true, Owner = this };
+            _lastWeeklySnapshotTimestamp    = parent.LastWeeklySnapshotTimestamp with { Value = DateTimeOffset.UnixEpoch, IsLocal = true, Owner = this };
+            _lastYearlySnapshotTimestamp    = parent.LastYearlySnapshotTimestamp with { Value = DateTimeOffset.UnixEpoch, IsLocal = true, Owner = this };
+            _pruneSnapshotsField            = parent.PruneSnapshots with { IsLocal = false, Owner = this };
+            _recursion                      = parent.Recursion with { IsLocal = false, Owner = this };
+            _snapshotRetentionDaily         = parent.SnapshotRetentionDaily with { IsLocal = false, Owner = this };
+            _snapshotRetentionFrequent      = parent.SnapshotRetentionFrequent with { IsLocal = false, Owner = this };
+            _snapshotRetentionHourly        = parent.SnapshotRetentionHourly with { IsLocal = false, Owner = this };
+            _snapshotRetentionMonthly       = parent.SnapshotRetentionMonthly with { IsLocal = false, Owner = this };
             _snapshotRetentionPruneDeferral = parent.SnapshotRetentionPruneDeferral with { IsLocal = false, Owner = this };
-            _snapshotRetentionWeekly = parent.SnapshotRetentionWeekly with { IsLocal = false, Owner = this };
-            _snapshotRetentionYearly = parent.SnapshotRetentionYearly with { IsLocal = false, Owner = this };
-            _sourceSystem = parent.SourceSystem with { IsLocal = false, Value = sourceSystem, Owner = this };
-            _takeSnapshots = parent.TakeSnapshots with { IsLocal = false, Owner = this };
-            _template = parent.Template with { IsLocal = false, Owner = this };
+            _snapshotRetentionWeekly        = parent.SnapshotRetentionWeekly with { IsLocal = false, Owner = this };
+            _snapshotRetentionYearly        = parent.SnapshotRetentionYearly with { IsLocal = false, Owner = this };
+            _sourceSystem                   = parent.SourceSystem with { IsLocal = false, Value = sourceSystem, Owner = this };
+            _takeSnapshots                  = parent.TakeSnapshots with { IsLocal = false, Owner = this };
+            _template                       = parent.Template with { IsLocal = false, Owner = this };
         }
         else
         {
-            _enabled = new( this, ZfsPropertyNames.EnabledPropertyName, false );
-            _lastDailySnapshotTimestamp = new( this, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
-            _lastFrequentSnapshotTimestamp = new( this, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
-            _lastHourlySnapshotTimestamp = new( this, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
-            _lastMonthlySnapshotTimestamp = new( this, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
-            _lastWeeklySnapshotTimestamp = new( this, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
-            _lastYearlySnapshotTimestamp = new( this, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
-            _pruneSnapshotsField = new( this, ZfsPropertyNames.PruneSnapshotsPropertyName, false );
-            _recursion = new( this, ZfsPropertyNames.RecursionPropertyName, ZfsPropertyValueConstants.SnapsInAZfs );
-            _snapshotRetentionDaily = new( this, ZfsPropertyNames.SnapshotRetentionDailyPropertyName, -1 );
-            _snapshotRetentionFrequent = new( this, ZfsPropertyNames.SnapshotRetentionFrequentPropertyName, -1 );
-            _snapshotRetentionHourly = new( this, ZfsPropertyNames.SnapshotRetentionHourlyPropertyName, -1 );
-            _snapshotRetentionMonthly = new( this, ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName, -1 );
-            _snapshotRetentionPruneDeferral = new( this, ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, 0 );
-            _snapshotRetentionWeekly = new( this, ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName, -1 );
-            _snapshotRetentionYearly = new( this, ZfsPropertyNames.SnapshotRetentionYearlyPropertyName, -1 );
-            _sourceSystem = new( this, ZfsPropertyNames.SourceSystem, sourceSystem );
-            _takeSnapshots = new( this, ZfsPropertyNames.TakeSnapshotsPropertyName, false );
-            _template = new( this, ZfsPropertyNames.TemplatePropertyName, ZfsPropertyValueConstants.Default );
+            _enabled                        = new ( this, ZfsPropertyNames.EnabledPropertyName, false );
+            _lastDailySnapshotTimestamp     = new ( this, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+            _lastFrequentSnapshotTimestamp  = new ( this, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+            _lastHourlySnapshotTimestamp    = new ( this, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+            _lastMonthlySnapshotTimestamp   = new ( this, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+            _lastWeeklySnapshotTimestamp    = new ( this, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+            _lastYearlySnapshotTimestamp    = new ( this, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+            _pruneSnapshotsField            = new ( this, ZfsPropertyNames.PruneSnapshotsPropertyName, false );
+            _recursion                      = new ( this, ZfsPropertyNames.RecursionPropertyName, ZfsPropertyValueConstants.SnapsInAZfs );
+            _snapshotRetentionDaily         = new ( this, ZfsPropertyNames.SnapshotRetentionDailyPropertyName, -1 );
+            _snapshotRetentionFrequent      = new ( this, ZfsPropertyNames.SnapshotRetentionFrequentPropertyName, -1 );
+            _snapshotRetentionHourly        = new ( this, ZfsPropertyNames.SnapshotRetentionHourlyPropertyName, -1 );
+            _snapshotRetentionMonthly       = new ( this, ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName, -1 );
+            _snapshotRetentionPruneDeferral = new ( this, ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, 0 );
+            _snapshotRetentionWeekly        = new ( this, ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName, -1 );
+            _snapshotRetentionYearly        = new ( this, ZfsPropertyNames.SnapshotRetentionYearlyPropertyName, -1 );
+            _sourceSystem                   = new ( this, ZfsPropertyNames.SourceSystem, sourceSystem );
+            _takeSnapshots                  = new ( this, ZfsPropertyNames.TakeSnapshotsPropertyName, false );
+            _template                       = new ( this, ZfsPropertyNames.TemplatePropertyName, ZfsPropertyValueConstants.Default );
         }
     }
 
     /// <exception cref="ArgumentException">sourceSystem must have a non-null, non-whitespace-only Value</exception>
-    protected ZfsRecord( string name, string kind, in ZfsProperty<bool> enabled, in ZfsProperty<bool> takeSnapshots, in ZfsProperty<bool> pruneSnapshots, in ZfsProperty<DateTimeOffset> lastFrequentSnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastHourlySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastDailySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastWeeklySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastMonthlySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastYearlySnapshotTimestamp, in ZfsProperty<string> recursion, in ZfsProperty<string> template, in ZfsProperty<int> retentionFrequent, in ZfsProperty<int> retentionHourly, in ZfsProperty<int> retentionDaily, in ZfsProperty<int> retentionWeekly, in ZfsProperty<int> retentionMonthly, in ZfsProperty<int> retentionYearly, in ZfsProperty<int> retentionPruneDeferral, in ZfsProperty<string> sourceSystem, in long bytesAvailable, in long bytesUsed, ZfsRecord? parent = null, bool forcePropertyOwnership = false )
+    protected ZfsRecord (
+        string                         name,
+        string                         kind,
+        in ZfsProperty<bool>           enabled,
+        in ZfsProperty<bool>           takeSnapshots,
+        in ZfsProperty<bool>           pruneSnapshots,
+        in ZfsProperty<DateTimeOffset> lastFrequentSnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastHourlySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastDailySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastWeeklySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastMonthlySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastYearlySnapshotTimestamp,
+        in ZfsProperty<string>         recursion,
+        in ZfsProperty<string>         template,
+        in ZfsProperty<int>            retentionFrequent,
+        in ZfsProperty<int>            retentionHourly,
+        in ZfsProperty<int>            retentionDaily,
+        in ZfsProperty<int>            retentionWeekly,
+        in ZfsProperty<int>            retentionMonthly,
+        in ZfsProperty<int>            retentionYearly,
+        in ZfsProperty<int>            retentionPruneDeferral,
+        in ZfsProperty<string>         sourceSystem,
+        in long                        bytesAvailable,
+        in long                        bytesUsed,
+        ZfsRecord?                     parent                 = null,
+        bool                           forcePropertyOwnership = false
+    )
     {
-        if ( string.IsNullOrWhiteSpace( sourceSystem.Value ) )
+        if ( string.IsNullOrWhiteSpace ( sourceSystem.Value ) )
         {
-            throw new ArgumentException( "sourceSystem must have a non-null, non-whitespace-only Value", nameof( sourceSystem ) );
+            throw new ArgumentException ( "sourceSystem must have a non-null, non-whitespace-only Value", nameof (sourceSystem) );
         }
 
-        Name = name;
-        IsPoolRoot = parent is null;
+        Name          = name;
+        IsPoolRoot    = parent is null;
         ParentDataset = parent ?? this;
-        Kind = kind;
+        Kind          = kind;
+
         NameValidatorRegex = kind switch
-        {
-            ZfsPropertyValueConstants.FileSystem => ZfsIdentifierRegexes.DatasetNameRegex( ),
-            ZfsPropertyValueConstants.Volume => ZfsIdentifierRegexes.DatasetNameRegex( ),
-            ZfsPropertyValueConstants.Snapshot => ZfsIdentifierRegexes.SnapshotNameRegex( ),
-            _ => throw new InvalidOperationException( "Unknown type of object specified for ZfsIdentifierValidator." )
-        };
+                             {
+                                 ZfsPropertyValueConstants.FileSystem => ZfsIdentifierRegexes.DatasetNameRegex ( ),
+                                 ZfsPropertyValueConstants.Volume     => ZfsIdentifierRegexes.DatasetNameRegex ( ),
+                                 ZfsPropertyValueConstants.Snapshot   => ZfsIdentifierRegexes.SnapshotNameRegex ( ),
+                                 _                                    => throw new InvalidOperationException ( "Unknown type of object specified for ZfsIdentifierValidator." )
+                             };
         bool notASnapshot = Kind != ZfsPropertyValueConstants.Snapshot;
         bool isASnapshot  = parent is { } && Kind == ZfsPropertyValueConstants.Snapshot;
 
         if ( forcePropertyOwnership || isASnapshot )
         {
-            _enabled = enabled with { Owner = this, IsLocal = notASnapshot && enabled.IsLocal };
-            _takeSnapshots = takeSnapshots with { Owner = this, IsLocal = notASnapshot && takeSnapshots.IsLocal };
+            _enabled             = enabled with { Owner = this, IsLocal = notASnapshot       && enabled.IsLocal };
+            _takeSnapshots       = takeSnapshots with { Owner = this, IsLocal = notASnapshot && takeSnapshots.IsLocal };
             _pruneSnapshotsField = pruneSnapshots with { Owner = this };
 
             _lastFrequentSnapshotTimestamp = notASnapshot && lastFrequentSnapshotTimestamp.IsLocal
-                ? lastFrequentSnapshotTimestamp with { Owner = this }
-                : new( this, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+                                                 ? lastFrequentSnapshotTimestamp with { Owner = this }
+                                                 : new ( this, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
 
             _lastHourlySnapshotTimestamp = notASnapshot && lastHourlySnapshotTimestamp.IsLocal
-                ? lastHourlySnapshotTimestamp with { Owner = this }
-                : new( this, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+                                               ? lastHourlySnapshotTimestamp with { Owner = this }
+                                               : new ( this, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
 
             _lastDailySnapshotTimestamp = notASnapshot && lastDailySnapshotTimestamp.IsLocal
-                ? lastDailySnapshotTimestamp with { Owner = this }
-                : new( this, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+                                              ? lastDailySnapshotTimestamp with { Owner = this }
+                                              : new ( this, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
 
             _lastWeeklySnapshotTimestamp = notASnapshot && lastWeeklySnapshotTimestamp.IsLocal
-                ? lastWeeklySnapshotTimestamp with { Owner = this }
-                : new( this, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+                                               ? lastWeeklySnapshotTimestamp with { Owner = this }
+                                               : new ( this, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
 
             _lastMonthlySnapshotTimestamp = notASnapshot && lastMonthlySnapshotTimestamp.IsLocal
-                ? lastMonthlySnapshotTimestamp with { Owner = this }
-                : new( this, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+                                                ? lastMonthlySnapshotTimestamp with { Owner = this }
+                                                : new ( this, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
 
             _lastYearlySnapshotTimestamp = notASnapshot && lastYearlySnapshotTimestamp.IsLocal
-                ? lastYearlySnapshotTimestamp with { Owner = this }
-                : new( this, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+                                               ? lastYearlySnapshotTimestamp with { Owner = this }
+                                               : new ( this, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
 
-            _recursion = recursion with { Owner = this, IsLocal = isASnapshot || recursion.IsLocal };
-            _template = template with { Owner = this, IsLocal = isASnapshot || template.IsLocal };
+            _recursion    = recursion with { Owner = this, IsLocal = isASnapshot || recursion.IsLocal };
+            _template     = template with { Owner = this, IsLocal = isASnapshot  || template.IsLocal };
             _sourceSystem = sourceSystem with { Owner = this };
 
-            _snapshotRetentionFrequent = retentionFrequent with { Owner = this, IsLocal = notASnapshot && retentionFrequent.IsLocal };
-            _snapshotRetentionHourly = retentionHourly with { Owner = this, IsLocal = notASnapshot && retentionHourly.IsLocal };
-            _snapshotRetentionDaily = retentionDaily with { Owner = this, IsLocal = notASnapshot && retentionDaily.IsLocal };
-            _snapshotRetentionWeekly = retentionWeekly with { Owner = this, IsLocal = notASnapshot && retentionWeekly.IsLocal };
-            _snapshotRetentionMonthly = retentionMonthly with { Owner = this, IsLocal = notASnapshot && retentionMonthly.IsLocal };
-            _snapshotRetentionYearly = retentionYearly with { Owner = this, IsLocal = notASnapshot && retentionYearly.IsLocal };
+            _snapshotRetentionFrequent      = retentionFrequent with { Owner = this, IsLocal = notASnapshot      && retentionFrequent.IsLocal };
+            _snapshotRetentionHourly        = retentionHourly with { Owner = this, IsLocal = notASnapshot        && retentionHourly.IsLocal };
+            _snapshotRetentionDaily         = retentionDaily with { Owner = this, IsLocal = notASnapshot         && retentionDaily.IsLocal };
+            _snapshotRetentionWeekly        = retentionWeekly with { Owner = this, IsLocal = notASnapshot        && retentionWeekly.IsLocal };
+            _snapshotRetentionMonthly       = retentionMonthly with { Owner = this, IsLocal = notASnapshot       && retentionMonthly.IsLocal };
+            _snapshotRetentionYearly        = retentionYearly with { Owner = this, IsLocal = notASnapshot        && retentionYearly.IsLocal };
             _snapshotRetentionPruneDeferral = retentionPruneDeferral with { Owner = this, IsLocal = notASnapshot && retentionPruneDeferral.IsLocal };
 
             BytesAvailable = isASnapshot ? parent!.BytesAvailable : bytesAvailable;
-            BytesUsed = isASnapshot ? parent!.BytesUsed : bytesUsed;
+            BytesUsed      = isASnapshot ? parent!.BytesUsed : bytesUsed;
         }
         else
         {
-            _enabled = enabled;
-            _takeSnapshots = takeSnapshots;
+            _enabled             = enabled;
+            _takeSnapshots       = takeSnapshots;
             _pruneSnapshotsField = pruneSnapshots;
 
             // If local, take what we were given. Otherwise, construct a default property, as this should NEVER be inherited
-            _lastFrequentSnapshotTimestamp = lastFrequentSnapshotTimestamp.IsLocal ? lastFrequentSnapshotTimestamp : new( this, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
-            _lastHourlySnapshotTimestamp = lastHourlySnapshotTimestamp.IsLocal ? lastHourlySnapshotTimestamp : new( this, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
-            _lastDailySnapshotTimestamp = lastDailySnapshotTimestamp.IsLocal ? lastDailySnapshotTimestamp : new( this, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
-            _lastWeeklySnapshotTimestamp = lastWeeklySnapshotTimestamp.IsLocal ? lastWeeklySnapshotTimestamp : new( this, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
-            _lastMonthlySnapshotTimestamp = lastMonthlySnapshotTimestamp.IsLocal ? lastMonthlySnapshotTimestamp : new( this, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
-            _lastYearlySnapshotTimestamp = lastYearlySnapshotTimestamp.IsLocal ? lastYearlySnapshotTimestamp : new( this, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+            _lastFrequentSnapshotTimestamp = lastFrequentSnapshotTimestamp.IsLocal ? lastFrequentSnapshotTimestamp : new ( this, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+            _lastHourlySnapshotTimestamp   = lastHourlySnapshotTimestamp.IsLocal ? lastHourlySnapshotTimestamp : new ( this, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+            _lastDailySnapshotTimestamp    = lastDailySnapshotTimestamp.IsLocal ? lastDailySnapshotTimestamp : new ( this, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+            _lastWeeklySnapshotTimestamp   = lastWeeklySnapshotTimestamp.IsLocal ? lastWeeklySnapshotTimestamp : new ( this, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+            _lastMonthlySnapshotTimestamp  = lastMonthlySnapshotTimestamp.IsLocal ? lastMonthlySnapshotTimestamp : new ( this, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
+            _lastYearlySnapshotTimestamp   = lastYearlySnapshotTimestamp.IsLocal ? lastYearlySnapshotTimestamp : new ( this, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch );
 
-            _recursion = recursion;
-            _template = template;
+            _recursion    = recursion;
+            _template     = template;
             _sourceSystem = sourceSystem;
 
-            _snapshotRetentionFrequent = retentionFrequent;
-            _snapshotRetentionHourly = retentionHourly;
-            _snapshotRetentionDaily = retentionDaily;
-            _snapshotRetentionWeekly = retentionWeekly;
-            _snapshotRetentionMonthly = retentionMonthly;
-            _snapshotRetentionYearly = retentionYearly;
+            _snapshotRetentionFrequent      = retentionFrequent;
+            _snapshotRetentionHourly        = retentionHourly;
+            _snapshotRetentionDaily         = retentionDaily;
+            _snapshotRetentionWeekly        = retentionWeekly;
+            _snapshotRetentionMonthly       = retentionMonthly;
+            _snapshotRetentionYearly        = retentionYearly;
             _snapshotRetentionPruneDeferral = retentionPruneDeferral;
-            BytesAvailable = bytesAvailable;
-            BytesUsed = bytesUsed;
+            BytesAvailable                  = bytesAvailable;
+            BytesUsed                       = bytesUsed;
         }
     }
 
     private ImmutableSortedDictionary<string, ZfsRecord>? _sortedChildDatasets;
 
     public long BytesAvailable { get; init; }
-    public long BytesUsed { get; init; }
+    public long BytesUsed      { get; init; }
 
-    public int ChildDatasetCount => _childDatasets.Count;
-    public bool IsPoolRoot { get; }
-    public string Kind { get; }
-    public DateTimeOffset LastObservedDailySnapshotTimestamp { get; private set; } = DateTimeOffset.UnixEpoch;
+    public int            ChildDatasetCount                     => _childDatasets.Count;
+    public bool           IsPoolRoot                            { get; }
+    public string         Kind                                  { get; }
+    public DateTimeOffset LastObservedDailySnapshotTimestamp    { get; private set; } = DateTimeOffset.UnixEpoch;
     public DateTimeOffset LastObservedFrequentSnapshotTimestamp { get; private set; } = DateTimeOffset.UnixEpoch;
-    public DateTimeOffset LastObservedHourlySnapshotTimestamp { get; private set; } = DateTimeOffset.UnixEpoch;
-    public DateTimeOffset LastObservedMonthlySnapshotTimestamp { get; private set; } = DateTimeOffset.UnixEpoch;
-    public DateTimeOffset LastObservedWeeklySnapshotTimestamp { get; private set; } = DateTimeOffset.UnixEpoch;
-    public DateTimeOffset LastObservedYearlySnapshotTimestamp { get; private set; } = DateTimeOffset.UnixEpoch;
-    public string Name { get; }
+    public DateTimeOffset LastObservedHourlySnapshotTimestamp   { get; private set; } = DateTimeOffset.UnixEpoch;
+    public DateTimeOffset LastObservedMonthlySnapshotTimestamp  { get; private set; } = DateTimeOffset.UnixEpoch;
+    public DateTimeOffset LastObservedWeeklySnapshotTimestamp   { get; private set; } = DateTimeOffset.UnixEpoch;
+    public DateTimeOffset LastObservedYearlySnapshotTimestamp   { get; private set; } = DateTimeOffset.UnixEpoch;
+    public string         Name                                  { get; }
 
     [JsonIgnore]
     public ZfsRecord ParentDataset { get; }
 
-    public int SnapshotCount => Snapshots.Values.Sum( static d => d.Count );
+    public int SnapshotCount => Snapshots.Values.Sum ( static d => d.Count );
 
-    public ConcurrentDictionary<SnapshotPeriodKind, ConcurrentDictionary<string, Snapshot>> Snapshots { get; } = GetNewSnapshotCollection( );
+    public ConcurrentDictionary<SnapshotPeriodKind, ConcurrentDictionary<string, Snapshot>> Snapshots { get; } = GetNewSnapshotCollection ( );
 
     public bool SubscribedToParentPropertyChangeEvents { get; private set; }
 
     [JsonIgnore]
     internal Regex NameValidatorRegex { get; }
 
-    private SortedDictionary<string, ZfsRecord> _childDatasets { get; } = new( );
+    private SortedDictionary<string, ZfsRecord> _childDatasets { get; } = new ( );
 
     [JsonIgnore]
     private long PercentBytesUsed => BytesUsed * 100 / BytesAvailable;
 
-    /// <inheritdoc />
-    public int CompareTo( ZfsRecord? other )
+    /// <inheritdoc/>
+    public int CompareTo ( ZfsRecord? other )
     {
         // If the other snapshot is null, consider this record earlier rank
         if ( other is null )
@@ -232,76 +266,75 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
             return -1;
         }
 
-        return string.Compare( Name, other.Name, StringComparison.Ordinal );
+        return string.Compare ( Name, other.Name, StringComparison.Ordinal );
     }
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     /// <remarks>
     ///     The default generated record equality causes stack overflow due to the self-reference in root datasets,
-    ///     so it is excluded from equality comparison.<br />
+    ///     so it is excluded from equality comparison.<br/>
     ///     This equality method ONLY checks value properties and does not check the content of collections or references to other
-    ///     <see cref="ZfsRecord" />s.<br />
-    ///     It does, however, check <see cref="SnapshotCount" /> and <see cref="ChildDatasetCount" />.
+    ///     <see cref="ZfsRecord"/>s.<br/>
+    ///     It does, however, check <see cref="SnapshotCount"/> and <see cref="ChildDatasetCount"/>.
     /// </remarks>
-    public virtual bool Equals( ZfsRecord? other )
-    {
+    public virtual bool Equals ( ZfsRecord? other ) =>
+
         // Returning equality of value properties alphabetically
-        return
-            other is { }
-         && BytesAvailable == other.BytesAvailable
-            && BytesUsed == other.BytesUsed
-            && Enabled == other.Enabled
-            && IsPoolRoot == other.IsPoolRoot
-            && Kind == other.Kind
-            && LastDailySnapshotTimestamp == other.LastDailySnapshotTimestamp
-            && LastFrequentSnapshotTimestamp == other.LastFrequentSnapshotTimestamp
-            && LastHourlySnapshotTimestamp == other.LastHourlySnapshotTimestamp
-            && LastMonthlySnapshotTimestamp == other.LastMonthlySnapshotTimestamp
-            && LastObservedDailySnapshotTimestamp == other.LastObservedDailySnapshotTimestamp
-            && LastObservedFrequentSnapshotTimestamp == other.LastObservedFrequentSnapshotTimestamp
-            && LastObservedHourlySnapshotTimestamp == other.LastObservedHourlySnapshotTimestamp
-            && LastObservedWeeklySnapshotTimestamp == other.LastObservedWeeklySnapshotTimestamp
-            && LastObservedMonthlySnapshotTimestamp == other.LastObservedMonthlySnapshotTimestamp
-            && LastObservedYearlySnapshotTimestamp == other.LastObservedYearlySnapshotTimestamp
-            && LastWeeklySnapshotTimestamp == other.LastWeeklySnapshotTimestamp
-            && LastYearlySnapshotTimestamp == other.LastYearlySnapshotTimestamp
-            && Name == other.Name
-            && PruneSnapshots == other.PruneSnapshots
-            && Recursion == other.Recursion
-            && SnapshotRetentionDaily == other.SnapshotRetentionDaily
-            && SnapshotRetentionFrequent == other.SnapshotRetentionFrequent
-            && SnapshotRetentionHourly == other.SnapshotRetentionHourly
-            && SnapshotRetentionMonthly == other.SnapshotRetentionMonthly
-            && SnapshotRetentionPruneDeferral == other.SnapshotRetentionPruneDeferral
-            && SnapshotRetentionWeekly == other.SnapshotRetentionWeekly
-            && SnapshotRetentionYearly == other.SnapshotRetentionYearly
-            && SourceSystem == other.SourceSystem
-            && TakeSnapshots == other.TakeSnapshots
-            && Template == other.Template
-            && SnapshotCount == other.SnapshotCount
-            && ChildDatasetCount == other.ChildDatasetCount;
-    }
+        other is { }
+     && BytesAvailable                        == other.BytesAvailable
+     && BytesUsed                             == other.BytesUsed
+     && Enabled                               == other.Enabled
+     && IsPoolRoot                            == other.IsPoolRoot
+     && Kind                                  == other.Kind
+     && LastDailySnapshotTimestamp            == other.LastDailySnapshotTimestamp
+     && LastFrequentSnapshotTimestamp         == other.LastFrequentSnapshotTimestamp
+     && LastHourlySnapshotTimestamp           == other.LastHourlySnapshotTimestamp
+     && LastMonthlySnapshotTimestamp          == other.LastMonthlySnapshotTimestamp
+     && LastObservedDailySnapshotTimestamp    == other.LastObservedDailySnapshotTimestamp
+     && LastObservedFrequentSnapshotTimestamp == other.LastObservedFrequentSnapshotTimestamp
+     && LastObservedHourlySnapshotTimestamp   == other.LastObservedHourlySnapshotTimestamp
+     && LastObservedWeeklySnapshotTimestamp   == other.LastObservedWeeklySnapshotTimestamp
+     && LastObservedMonthlySnapshotTimestamp  == other.LastObservedMonthlySnapshotTimestamp
+     && LastObservedYearlySnapshotTimestamp   == other.LastObservedYearlySnapshotTimestamp
+     && LastWeeklySnapshotTimestamp           == other.LastWeeklySnapshotTimestamp
+     && LastYearlySnapshotTimestamp           == other.LastYearlySnapshotTimestamp
+     && Name                                  == other.Name
+     && PruneSnapshots                        == other.PruneSnapshots
+     && Recursion                             == other.Recursion
+     && SnapshotRetentionDaily                == other.SnapshotRetentionDaily
+     && SnapshotRetentionFrequent             == other.SnapshotRetentionFrequent
+     && SnapshotRetentionHourly               == other.SnapshotRetentionHourly
+     && SnapshotRetentionMonthly              == other.SnapshotRetentionMonthly
+     && SnapshotRetentionPruneDeferral        == other.SnapshotRetentionPruneDeferral
+     && SnapshotRetentionWeekly               == other.SnapshotRetentionWeekly
+     && SnapshotRetentionYearly               == other.SnapshotRetentionYearly
+     && SourceSystem                          == other.SourceSystem
+     && TakeSnapshots                         == other.TakeSnapshots
+     && Template                              == other.Template
+     && SnapshotCount                         == other.SnapshotCount
+     && ChildDatasetCount                     == other.ChildDatasetCount;
 
     /// <exception cref="ArgumentException">
-    ///     If the <see cref="ParentDataset" /> property of <paramref name="childDataset" /> does not reference this
-    ///     <see cref="ZfsRecord" /> instance.
+    ///     If the <see cref="ParentDataset"/> property of <paramref name="childDataset"/> does not reference this
+    ///     <see cref="ZfsRecord"/> instance.
     /// </exception>
-    public void AddDataset( ZfsRecord childDataset )
+    public void AddDataset ( ZfsRecord childDataset )
     {
-        if ( !ReferenceEquals( childDataset.ParentDataset, this ) )
+        if ( !ReferenceEquals ( childDataset.ParentDataset, this ) )
         {
-            throw new ArgumentException( $"Cannot add child dataset to {Name}. {childDataset.Name} already references parent {childDataset.ParentDataset.Name}.", nameof( childDataset ) );
+            throw new ArgumentException ( $"Cannot add child dataset to {Name}. {childDataset.Name} already references parent {childDataset.ParentDataset.Name}.", nameof (childDataset) );
         }
 
-        SubscribeChildToPropertyEvents( childDataset );
-        _childDatasets[ childDataset.Name ] = childDataset;
+        SubscribeChildToPropertyEvents ( childDataset );
+        _childDatasets [ childDataset.Name ] = childDataset;
     }
 
-    public Snapshot AddSnapshot( Snapshot snap )
+    public Snapshot AddSnapshot ( Snapshot snap )
     {
-        Logger.Trace( "Adding snapshot {0} to {1} {2}", snap.Name, Kind, Name );
-        SnapshotPeriodKind periodKind = snap.Period.Value.ToSnapshotPeriodKind( );
-        Snapshots[ periodKind ][ snap.Name ] = snap;
+        Logger.Trace ( "Adding snapshot {0} to {1} {2}", snap.Name, Kind, Name );
+        SnapshotPeriodKind periodKind = snap.Period.Value.ToSnapshotPeriodKind ( );
+        Snapshots [ periodKind ] [ snap.Name ] = snap;
+
         switch ( periodKind )
         {
             case SnapshotPeriodKind.Frequent:
@@ -348,23 +381,50 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
                 break;
             case SnapshotPeriodKind.NotSet:
             default:
-                throw new InvalidOperationException( "Invalid Snapshot Period specified" );
+                throw new InvalidOperationException ( "Invalid Snapshot Period specified" );
         }
 
-        SubscribeSnapshotToPropertyEvents( snap );
+        SubscribeSnapshotToPropertyEvents ( snap );
+
         return snap;
     }
 
     /// <exception cref="ArgumentException">sourceSystem must have a non-null, non-whitespace-only Value</exception>
-    public Snapshot CreateAndAddSnapshot( string snapName, in ZfsProperty<bool> enabled, in ZfsProperty<bool> takeSnapshots, in ZfsProperty<bool> pruneSnapshots, in ZfsProperty<DateTimeOffset> lastFrequentSnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastHourlySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastDailySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastWeeklySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastMonthlySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastYearlySnapshotTimestamp, in ZfsProperty<string> recursion, in ZfsProperty<string> template, in ZfsProperty<int> retentionFrequent, in ZfsProperty<int> retentionHourly, in ZfsProperty<int> retentionDaily, in ZfsProperty<int> retentionWeekly, in ZfsProperty<int> retentionMonthly, in ZfsProperty<int> retentionYearly, in ZfsProperty<int> retentionPruneDeferral, string periodString, in ZfsProperty<string> sourceSystem, in DateTimeOffset snapshotTimestamp, ZfsRecord dataset )
+    public Snapshot CreateAndAddSnapshot (
+        string                         snapName,
+        in ZfsProperty<bool>           enabled,
+        in ZfsProperty<bool>           takeSnapshots,
+        in ZfsProperty<bool>           pruneSnapshots,
+        in ZfsProperty<DateTimeOffset> lastFrequentSnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastHourlySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastDailySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastWeeklySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastMonthlySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastYearlySnapshotTimestamp,
+        in ZfsProperty<string>         recursion,
+        in ZfsProperty<string>         template,
+        in ZfsProperty<int>            retentionFrequent,
+        in ZfsProperty<int>            retentionHourly,
+        in ZfsProperty<int>            retentionDaily,
+        in ZfsProperty<int>            retentionWeekly,
+        in ZfsProperty<int>            retentionMonthly,
+        in ZfsProperty<int>            retentionYearly,
+        in ZfsProperty<int>            retentionPruneDeferral,
+        string                         periodString,
+        in ZfsProperty<string>         sourceSystem,
+        in DateTimeOffset              snapshotTimestamp,
+        ZfsRecord                      dataset
+    )
     {
-        Logger.Trace( "Creating and adding snapshot {0} to {1} {2}", snapName, Kind, Name );
-        if ( string.IsNullOrWhiteSpace( sourceSystem.Value ) )
+        Logger.Trace ( "Creating and adding snapshot {0} to {1} {2}", snapName, Kind, Name );
+
+        if ( string.IsNullOrWhiteSpace ( sourceSystem.Value ) )
         {
-            throw new ArgumentException( "sourceSystem must have a non-null, non-whitespace-only Value", nameof( sourceSystem ) );
+            throw new ArgumentException ( "sourceSystem must have a non-null, non-whitespace-only Value", nameof (sourceSystem) );
         }
 
-        Snapshot snap = new( snapName,
+        Snapshot snap = new (
+                             snapName,
                              enabled,
                              takeSnapshots,
                              pruneSnapshots,
@@ -387,113 +447,172 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
                              periodString,
                              snapshotTimestamp,
                              dataset );
-        AddSnapshot( snap );
+        AddSnapshot ( snap );
+
         return snap;
     }
 
     /// <exception cref="ArgumentNullException">
-    ///     <paramref name="sourceSystem" /> is <see langword="null" />, empty, or only whitespace
+    ///     <paramref name="sourceSystem"/> is <see langword="null"/>, empty, or only whitespace
     /// </exception>
-    public ZfsRecord CreateChildDataset( string name, string kind, string sourceSystem = "", bool inheritProperties = true, long bytesAvailable = -1, long bytesUsed = -1 )
+    public ZfsRecord CreateChildDataset ( string name, string kind, string sourceSystem = "", bool inheritProperties = true, long bytesAvailable = -1, long bytesUsed = -1 )
     {
-        if ( string.IsNullOrWhiteSpace( sourceSystem ) )
+        if ( string.IsNullOrWhiteSpace ( sourceSystem ) )
         {
-            throw new ArgumentNullException( nameof( sourceSystem ) );
+            throw new ArgumentNullException ( nameof (sourceSystem) );
         }
 
         bool propertiesLocal = !inheritProperties;
-        ZfsRecord newDs = inheritProperties
-            ? new( name,
-                   kind,
-                   Enabled with { IsLocal = propertiesLocal },
-                   TakeSnapshots with { IsLocal = propertiesLocal },
-                   PruneSnapshots with { IsLocal = propertiesLocal },
-                   LastFrequentSnapshotTimestamp with { IsLocal = true, Value = DateTimeOffset.UnixEpoch },
-                   LastHourlySnapshotTimestamp with { IsLocal = true, Value = DateTimeOffset.UnixEpoch },
-                   LastDailySnapshotTimestamp with { IsLocal = true, Value = DateTimeOffset.UnixEpoch },
-                   LastWeeklySnapshotTimestamp with { IsLocal = true, Value = DateTimeOffset.UnixEpoch },
-                   LastMonthlySnapshotTimestamp with { IsLocal = true, Value = DateTimeOffset.UnixEpoch },
-                   LastYearlySnapshotTimestamp with { IsLocal = true, Value = DateTimeOffset.UnixEpoch },
-                   Recursion with { IsLocal = propertiesLocal },
-                   Template with { IsLocal = propertiesLocal },
-                   SnapshotRetentionFrequent with { IsLocal = propertiesLocal },
-                   SnapshotRetentionHourly with { IsLocal = propertiesLocal },
-                   SnapshotRetentionDaily with { IsLocal = propertiesLocal },
-                   SnapshotRetentionWeekly with { IsLocal = propertiesLocal },
-                   SnapshotRetentionMonthly with { IsLocal = propertiesLocal },
-                   SnapshotRetentionYearly with { IsLocal = propertiesLocal },
-                   SnapshotRetentionPruneDeferral with { IsLocal = propertiesLocal },
-                   SourceSystem with { IsLocal = true, Value = sourceSystem },
-                   bytesAvailable,
-                   bytesUsed,
-                   this,
-                   true )
-            : new( name, kind, sourceSystem, false, this )
-            {
-                BytesAvailable = bytesAvailable,
-                BytesUsed = bytesUsed
-            };
 
-        AddDataset( newDs );
+        ZfsRecord newDs = inheritProperties
+                              ? new (
+                                     name,
+                                     kind,
+                                     Enabled with { IsLocal = propertiesLocal },
+                                     TakeSnapshots with { IsLocal = propertiesLocal },
+                                     PruneSnapshots with { IsLocal = propertiesLocal },
+                                     LastFrequentSnapshotTimestamp with { IsLocal = true, Value = DateTimeOffset.UnixEpoch },
+                                     LastHourlySnapshotTimestamp with { IsLocal = true, Value = DateTimeOffset.UnixEpoch },
+                                     LastDailySnapshotTimestamp with { IsLocal = true, Value = DateTimeOffset.UnixEpoch },
+                                     LastWeeklySnapshotTimestamp with { IsLocal = true, Value = DateTimeOffset.UnixEpoch },
+                                     LastMonthlySnapshotTimestamp with { IsLocal = true, Value = DateTimeOffset.UnixEpoch },
+                                     LastYearlySnapshotTimestamp with { IsLocal = true, Value = DateTimeOffset.UnixEpoch },
+                                     Recursion with { IsLocal = propertiesLocal },
+                                     Template with { IsLocal = propertiesLocal },
+                                     SnapshotRetentionFrequent with { IsLocal = propertiesLocal },
+                                     SnapshotRetentionHourly with { IsLocal = propertiesLocal },
+                                     SnapshotRetentionDaily with { IsLocal = propertiesLocal },
+                                     SnapshotRetentionWeekly with { IsLocal = propertiesLocal },
+                                     SnapshotRetentionMonthly with { IsLocal = propertiesLocal },
+                                     SnapshotRetentionYearly with { IsLocal = propertiesLocal },
+                                     SnapshotRetentionPruneDeferral with { IsLocal = propertiesLocal },
+                                     SourceSystem with { IsLocal = true, Value = sourceSystem },
+                                     bytesAvailable,
+                                     bytesUsed,
+                                     this,
+                                     true )
+                              : new ( name, kind, sourceSystem, false, this )
+                                {
+                                    BytesAvailable = bytesAvailable,
+                                    BytesUsed      = bytesUsed
+                                };
+
+        AddDataset ( newDs );
+
         return newDs;
     }
 
     /// <exception cref="ArgumentException">sourceSystem must have a non-null, non-whitespace-only Value</exception>
-    public static ZfsRecord CreateInstanceFromAllProperties( string name, string kind, in ZfsProperty<bool> enabled, in ZfsProperty<bool> takeSnapshots, in ZfsProperty<bool> pruneSnapshots, in ZfsProperty<DateTimeOffset> lastFrequentSnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastHourlySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastDailySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastWeeklySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastMonthlySnapshotTimestamp, in ZfsProperty<DateTimeOffset> lastYearlySnapshotTimestamp, in ZfsProperty<string> recursion, in ZfsProperty<string> template, in ZfsProperty<int> retentionFrequent, in ZfsProperty<int> retentionHourly, in ZfsProperty<int> retentionDaily, in ZfsProperty<int> retentionWeekly, in ZfsProperty<int> retentionMonthly, in ZfsProperty<int> retentionYearly, in ZfsProperty<int> retentionPruneDeferral, in ZfsProperty<string> sourceSystem, in long bytesAvailable, in long bytesUsed, ZfsRecord? parent = null )
+    public static ZfsRecord CreateInstanceFromAllProperties (
+        string                         name,
+        string                         kind,
+        in ZfsProperty<bool>           enabled,
+        in ZfsProperty<bool>           takeSnapshots,
+        in ZfsProperty<bool>           pruneSnapshots,
+        in ZfsProperty<DateTimeOffset> lastFrequentSnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastHourlySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastDailySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastWeeklySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastMonthlySnapshotTimestamp,
+        in ZfsProperty<DateTimeOffset> lastYearlySnapshotTimestamp,
+        in ZfsProperty<string>         recursion,
+        in ZfsProperty<string>         template,
+        in ZfsProperty<int>            retentionFrequent,
+        in ZfsProperty<int>            retentionHourly,
+        in ZfsProperty<int>            retentionDaily,
+        in ZfsProperty<int>            retentionWeekly,
+        in ZfsProperty<int>            retentionMonthly,
+        in ZfsProperty<int>            retentionYearly,
+        in ZfsProperty<int>            retentionPruneDeferral,
+        in ZfsProperty<string>         sourceSystem,
+        in long                        bytesAvailable,
+        in long                        bytesUsed,
+        ZfsRecord?                     parent = null
+    )
     {
-        if ( string.IsNullOrWhiteSpace( sourceSystem.Value ) )
+        if ( string.IsNullOrWhiteSpace ( sourceSystem.Value ) )
         {
-            throw new ArgumentException( "sourceSystem must have a non-null, non-whitespace-only Value", nameof( sourceSystem ) );
+            throw new ArgumentException ( "sourceSystem must have a non-null, non-whitespace-only Value", nameof (sourceSystem) );
         }
-        return new( name, kind, in enabled, in takeSnapshots, in pruneSnapshots, in lastFrequentSnapshotTimestamp, in lastHourlySnapshotTimestamp, in lastDailySnapshotTimestamp, in lastWeeklySnapshotTimestamp, in lastMonthlySnapshotTimestamp, in lastYearlySnapshotTimestamp, in recursion, in template, in retentionFrequent, in retentionHourly, in retentionDaily, in retentionWeekly, in retentionMonthly, in retentionYearly, in retentionPruneDeferral, in sourceSystem, in bytesAvailable, in bytesUsed, parent, true );
+
+        return new (
+                    name,
+                    kind,
+                    in enabled,
+                    in takeSnapshots,
+                    in pruneSnapshots,
+                    in lastFrequentSnapshotTimestamp,
+                    in lastHourlySnapshotTimestamp,
+                    in lastDailySnapshotTimestamp,
+                    in lastWeeklySnapshotTimestamp,
+                    in lastMonthlySnapshotTimestamp,
+                    in lastYearlySnapshotTimestamp,
+                    in recursion,
+                    in template,
+                    in retentionFrequent,
+                    in retentionHourly,
+                    in retentionDaily,
+                    in retentionWeekly,
+                    in retentionMonthly,
+                    in retentionYearly,
+                    in retentionPruneDeferral,
+                    in sourceSystem,
+                    in bytesAvailable,
+                    in bytesUsed,
+                    parent,
+                    true );
     }
 
     /// <summary>
-    ///     Creates a new <see cref="Snapshot" /> from the given <paramref name="period" /> and <paramref name="timestamp" />,
-    ///     using <paramref name="formattingSettings" /> to generate its name.
+    ///     Creates a new <see cref="Snapshot"/> from the given <paramref name="period"/> and <paramref name="timestamp"/>,
+    ///     using <paramref name="formattingSettings"/> to generate its name.
     /// </summary>
-    /// <param name="period">The period for the new <see cref="Snapshot" /></param>
-    /// <param name="timestamp">The timestamp for the new <see cref="Snapshot" /></param>
+    /// <param name="period">The period for the new <see cref="Snapshot"/></param>
+    /// <param name="timestamp">The timestamp for the new <see cref="Snapshot"/></param>
     /// <param name="formattingSettings"></param>
     /// <param name="sourceSystem"></param>
     /// <returns>
-    ///     A reference to the created <see cref="Snapshot" />
+    ///     A reference to the created <see cref="Snapshot"/>
     /// </returns>
-    public Snapshot CreateSnapshot( in SnapshotPeriod period, in DateTimeOffset timestamp, in FormattingSettings formattingSettings, in ZfsProperty<string> sourceSystem )
+    public Snapshot CreateSnapshot ( in SnapshotPeriod period, in DateTimeOffset timestamp, in FormattingSettings formattingSettings, in ZfsProperty<string> sourceSystem )
     {
-        Logger.Trace( "Creating {0} snapshot for {1} {2}", period, Kind, Name );
-        if ( string.IsNullOrWhiteSpace( sourceSystem.Value ) )
+        Logger.Trace ( "Creating {0} snapshot for {1} {2}", period, Kind, Name );
+
+        if ( string.IsNullOrWhiteSpace ( sourceSystem.Value ) )
         {
-            throw new ArgumentException( "sourceSystem must have a non-null, non-whitespace-only Value", nameof( sourceSystem ) );
+            throw new ArgumentException ( "sourceSystem must have a non-null, non-whitespace-only Value", nameof (sourceSystem) );
         }
-        string snapName = formattingSettings.GenerateFullSnapshotName( Name, in period.Kind, in timestamp );
-        Snapshot snap = new( snapName, in period.Kind, in sourceSystem, in timestamp, this );
+
+        string   snapName = formattingSettings.GenerateFullSnapshotName ( Name, in period.Kind, in timestamp );
+        Snapshot snap     = new ( snapName, in period.Kind, in sourceSystem, in timestamp, this );
+
         return snap;
     }
 
     /// <summary>
-    ///     Performs a deep copy of this <see cref="ZfsRecord" />
+    ///     Performs a deep copy of this <see cref="ZfsRecord"/>
     /// </summary>
     /// <param name="parent">
-    ///     A reference to the parent of the new <see cref="ZfsRecord" /> or <see langword="null" />, if the record to be cloned should
+    ///     A reference to the parent of the new <see cref="ZfsRecord"/> or <see langword="null"/>, if the record to be cloned should
     ///     be a pool root
     /// </param>
     /// <remarks>
     ///     The default copy constructor generated by the compiler performs a shallow copy and is unaware of the tree structure, which
-    ///     would mean that the <see cref="Snapshots" /> and <see cref="_childDatasets" />
-    ///     collections would contain references to the original record<br />
-    ///     This method loops over both collections, calling <see cref="DeepCopyClone" /> for every element of
-    ///     <see cref="_childDatasets" /> and <see cref="Snapshot.DeepCopyClone" /> for every <see cref="Snapshot" /> in
-    ///     <see cref="Snapshots" />.<br />
+    ///     would mean that the <see cref="Snapshots"/> and <see cref="_childDatasets"/>
+    ///     collections would contain references to the original record<br/>
+    ///     This method loops over both collections, calling <see cref="DeepCopyClone"/> for every element of
+    ///     <see cref="_childDatasets"/> and <see cref="Snapshot.DeepCopyClone"/> for every <see cref="Snapshot"/> in
+    ///     <see cref="Snapshots"/>.<br/>
     ///     THIS WILL RESULT IN A CLONE OF THE ENTIRE TREE FROM THIS NODE, INCLUDING ALL EVENT SUBSCRIPTIONS.
     /// </remarks>
     /// <returns>
-    ///     A new instance of a <see cref="ZfsRecord" />, with all properties, both reference and value, cloned to new instances
+    ///     A new instance of a <see cref="ZfsRecord"/>, with all properties, both reference and value, cloned to new instances
     /// </returns>
-    public virtual ZfsRecord DeepCopyClone( ZfsRecord? parent = null )
+    public virtual ZfsRecord DeepCopyClone ( ZfsRecord? parent = null )
     {
-        ZfsRecord newRecord = new( new( Name ),
-                                   new( Kind ),
+        ZfsRecord newRecord = new (
+                                   new ( Name ),
+                                   new ( Kind ),
                                    Enabled,
                                    TakeSnapshots,
                                    PruneSnapshots,
@@ -517,25 +636,25 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
                                    BytesUsed,
                                    parent,
                                    true )
-        {
-            LastObservedFrequentSnapshotTimestamp = LastObservedFrequentSnapshotTimestamp,
-            LastObservedHourlySnapshotTimestamp = LastObservedHourlySnapshotTimestamp,
-            LastObservedDailySnapshotTimestamp = LastObservedDailySnapshotTimestamp,
-            LastObservedWeeklySnapshotTimestamp = LastObservedWeeklySnapshotTimestamp,
-            LastObservedMonthlySnapshotTimestamp = LastObservedMonthlySnapshotTimestamp,
-            LastObservedYearlySnapshotTimestamp = LastObservedYearlySnapshotTimestamp
-        };
+                              {
+                                  LastObservedFrequentSnapshotTimestamp = LastObservedFrequentSnapshotTimestamp,
+                                  LastObservedHourlySnapshotTimestamp   = LastObservedHourlySnapshotTimestamp,
+                                  LastObservedDailySnapshotTimestamp    = LastObservedDailySnapshotTimestamp,
+                                  LastObservedWeeklySnapshotTimestamp   = LastObservedWeeklySnapshotTimestamp,
+                                  LastObservedMonthlySnapshotTimestamp  = LastObservedMonthlySnapshotTimestamp,
+                                  LastObservedYearlySnapshotTimestamp   = LastObservedYearlySnapshotTimestamp
+                              };
 
         foreach ( ( string _, ZfsRecord childDs ) in _childDatasets )
         {
-            newRecord.AddDataset( childDs.DeepCopyClone( newRecord ) );
+            newRecord.AddDataset ( childDs.DeepCopyClone ( newRecord ) );
         }
 
         foreach ( ( SnapshotPeriodKind _, ConcurrentDictionary<string, Snapshot> periodCollection ) in Snapshots )
         {
             foreach ( ( string _, Snapshot sourceSnap ) in periodCollection )
             {
-                newRecord.AddSnapshot( sourceSnap.DeepCopyClone( newRecord ) );
+                newRecord.AddSnapshot ( sourceSnap.DeepCopyClone ( newRecord ) );
             }
         }
 
@@ -543,216 +662,225 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
     }
 
     /// <summary>
-    ///     Gets a child <see cref="ZfsRecord" /> from this <see cref="ZfsRecord" />, by name, or <see langword="null" />, if no such
+    ///     Gets a child <see cref="ZfsRecord"/> from this <see cref="ZfsRecord"/>, by name, or <see langword="null"/>, if no such
     ///     child exists.
     /// </summary>
-    /// <param name="childName">The fully-qualified name of the <see cref="ZfsRecord" /> to retrieve</param>
+    /// <param name="childName">The fully-qualified name of the <see cref="ZfsRecord"/> to retrieve</param>
     /// <param name="child">
-    ///     An <see langword="out" /> reference to the child <see cref="ZfsRecord" />, if found
+    ///     An <see langword="out"/> reference to the child <see cref="ZfsRecord"/>, if found
     /// </param>
     /// <returns>
-    ///     If <paramref name="childName" /> is found, <see langword="true" />; Otherwise, <see langword="false" />
+    ///     If <paramref name="childName"/> is found, <see langword="true"/>; Otherwise, <see langword="false"/>
     /// </returns>
-    public bool GetChild( string childName, [NotNullWhen( true )] out ZfsRecord? child )
-    {
-        return _childDatasets.TryGetValue( childName, out child );
-    }
+    public bool GetChild ( string childName, [NotNullWhen ( true )] out ZfsRecord? child ) => _childDatasets.TryGetValue ( childName, out child );
 
-    /// <inheritdoc />
+    /// <inheritdoc/>
     /// <remarks>
     ///     Uses name and kind only, since they are the only truly immutable properties relevant to this function
     /// </remarks>
-    public override int GetHashCode( )
+    public override int GetHashCode ( )
     {
-        HashCode hashCode = new( );
-        hashCode.Add( Kind, StringComparer.CurrentCulture );
-        hashCode.Add( Name, StringComparer.CurrentCulture );
-        return hashCode.ToHashCode( );
+        HashCode hashCode = new ( );
+        hashCode.Add ( Kind, StringComparer.CurrentCulture );
+        hashCode.Add ( Name, StringComparer.CurrentCulture );
+
+        return hashCode.ToHashCode ( );
     }
 
-    public List<Snapshot> GetSnapshotsToPrune( )
+    public List<Snapshot> GetSnapshotsToPrune ( )
     {
-        Logger.Debug( "Getting list of snapshots to prune for dataset {0}", Name );
+        Logger.Debug ( "Getting list of snapshots to prune for dataset {0}", Name );
+
         if ( !Enabled.Value )
         {
-            Logger.Debug( "Dataset {0} is disabled. Skipping pruning", Name );
-            return [];
+            Logger.Debug ( "Dataset {0} is disabled. Skipping pruning", Name );
+
+            return [ ];
         }
 
         if ( !_pruneSnapshotsField.Value )
         {
-            Logger.Debug( "Dataset {0} is not enabled for pruning", Name );
-            return [];
+            Logger.Debug ( "Dataset {0} is not enabled for pruning", Name );
+
+            return [ ];
         }
 
-        Logger.Debug( "Checking prune deferral setting for dataset {0}", Name );
+        Logger.Debug ( "Checking prune deferral setting for dataset {0}", Name );
+
         if ( SnapshotRetentionPruneDeferral.Value != 0 && PercentBytesUsed < SnapshotRetentionPruneDeferral.Value )
         {
-            Logger.Info( "Used capacity for {0} ({1}%) is below prune deferral threshold of {2}%. Skipping pruning of {0}", Name, PercentBytesUsed, SnapshotRetentionPruneDeferral.Value );
-            return [];
+            Logger.Info ( "Used capacity for {0} ({1}%) is below prune deferral threshold of {2}%. Skipping pruning of {0}", Name, PercentBytesUsed, SnapshotRetentionPruneDeferral.Value );
+
+            return [ ];
         }
 
         if ( SnapshotRetentionPruneDeferral.Value == 0 )
         {
-            Logger.Debug( "Prune deferral not enabled for {0}", Name );
+            Logger.Debug ( "Prune deferral not enabled for {0}", Name );
         }
 
-        List<Snapshot> snapshotsToPrune = [];
+        List<Snapshot> snapshotsToPrune = [ ];
 
-        GetSnapshotsToPruneForPeriod( SnapshotPeriod.Frequent, SnapshotRetentionFrequent.Value, snapshotsToPrune );
-        GetSnapshotsToPruneForPeriod( SnapshotPeriod.Hourly, SnapshotRetentionHourly.Value, snapshotsToPrune );
-        GetSnapshotsToPruneForPeriod( SnapshotPeriod.Daily, SnapshotRetentionDaily.Value, snapshotsToPrune );
-        GetSnapshotsToPruneForPeriod( SnapshotPeriod.Weekly, SnapshotRetentionWeekly.Value, snapshotsToPrune );
-        GetSnapshotsToPruneForPeriod( SnapshotPeriod.Monthly, SnapshotRetentionMonthly.Value, snapshotsToPrune );
-        GetSnapshotsToPruneForPeriod( SnapshotPeriod.Yearly, SnapshotRetentionYearly.Value, snapshotsToPrune );
+        GetSnapshotsToPruneForPeriod ( SnapshotPeriod.Frequent, SnapshotRetentionFrequent.Value, snapshotsToPrune );
+        GetSnapshotsToPruneForPeriod ( SnapshotPeriod.Hourly,   SnapshotRetentionHourly.Value,   snapshotsToPrune );
+        GetSnapshotsToPruneForPeriod ( SnapshotPeriod.Daily,    SnapshotRetentionDaily.Value,    snapshotsToPrune );
+        GetSnapshotsToPruneForPeriod ( SnapshotPeriod.Weekly,   SnapshotRetentionWeekly.Value,   snapshotsToPrune );
+        GetSnapshotsToPruneForPeriod ( SnapshotPeriod.Monthly,  SnapshotRetentionMonthly.Value,  snapshotsToPrune );
+        GetSnapshotsToPruneForPeriod ( SnapshotPeriod.Yearly,   SnapshotRetentionYearly.Value,   snapshotsToPrune );
 
         return snapshotsToPrune;
     }
 
     /// <summary>
-    ///     Gets and caches a sorted dictionary of the child datasets of this <see cref="ZfsRecord" />
+    ///     Gets and caches a sorted dictionary of the child datasets of this <see cref="ZfsRecord"/>
     /// </summary>
     /// <returns></returns>
-    public ImmutableSortedDictionary<string, ZfsRecord> GetSortedChildDatasets( )
-    {
-        return _sortedChildDatasets ??= _childDatasets.ToImmutableSortedDictionary( );
-    }
+    public ImmutableSortedDictionary<string, ZfsRecord> GetSortedChildDatasets ( ) { return _sortedChildDatasets ??= _childDatasets.ToImmutableSortedDictionary ( ); }
 
     /// <summary>
-    ///     Gets whether a daily snapshot is needed, according to the <paramref name="timestamp" /> and the properties defined
+    ///     Gets whether a daily snapshot is needed, according to the <paramref name="timestamp"/> and the properties defined
     ///     on the object
     /// </summary>
     /// <param name="timestamp">
-    ///     The <see cref="DateTimeOffset" /> value to check against the last known snapshot of this type
+    ///     The <see cref="DateTimeOffset"/> value to check against the last known snapshot of this type
     /// </param>
     /// <returns>
-    ///     A <see langword="bool" /> indicating whether ALL of the following conditions are met:
+    ///     A <see langword="bool"/> indicating whether ALL of the following conditions are met:
     ///     <list type="bullet">
     ///         <item>
     ///             <description>Snapshot retention settings define daily greater than 0</description>
     ///         </item>
     ///         <item>
     ///             <description>
-    ///                 <paramref name="timestamp" /> is either more than one day ahead of the last daily
+    ///                 <paramref name="timestamp"/> is either more than one day ahead of the last daily
     ///                 snapshot OR the last daily snapshot is not in the same day of the year
     ///             </description>
     ///         </item>
     ///     </list>
     /// </returns>
-    public bool IsDailySnapshotNeeded( in DateTimeOffset timestamp )
+    public bool IsDailySnapshotNeeded ( in DateTimeOffset timestamp )
     {
         //Exit early if retention settings say no dailies
-        if ( !SnapshotRetentionDaily.IsWanted( ) )
+        if ( !SnapshotRetentionDaily.IsWanted ( ) )
         {
             return false;
         }
 
         // Yes, this can all be done in-line, but this is easier to debug, is more explicit, and the compiler is
         // going to optimize it all away anyway.
-        Logger.Trace( "Checking if daily snapshot is needed for dataset {0} at timestamp {1:O}", Name, timestamp );
+        Logger.Trace ( "Checking if daily snapshot is needed for dataset {0} at timestamp {1:O}", Name, timestamp );
+
         if ( timestamp <= LastDailySnapshotTimestamp.Value )
         {
             return false;
         }
 
-        TimeSpan timeSinceLastDailySnapshot = timestamp - LastDailySnapshotTimestamp.Value;
-        bool atLeastOneDaySinceLastDailySnapshot = timeSinceLastDailySnapshot.TotalDays >= 1d;
+        TimeSpan timeSinceLastDailySnapshot          = timestamp - LastDailySnapshotTimestamp.Value;
+        bool     atLeastOneDaySinceLastDailySnapshot = timeSinceLastDailySnapshot.TotalDays >= 1d;
+
         // Check if more than a day ago or if a different day of the year
         bool lastDailyOnDifferentDayOfYear = LastDailySnapshotTimestamp.Value.LocalDateTime.DayOfYear != timestamp.LocalDateTime.DayOfYear;
-        bool dailySnapshotNeeded = atLeastOneDaySinceLastDailySnapshot || lastDailyOnDifferentDayOfYear;
-        Logger.Debug( "Daily snapshot is {2}needed for dataset {0} at timestamp {1:O}", Name, timestamp, dailySnapshotNeeded ? "" : "not " );
+        bool dailySnapshotNeeded           = atLeastOneDaySinceLastDailySnapshot || lastDailyOnDifferentDayOfYear;
+        Logger.Debug ( "Daily snapshot is {2}needed for dataset {0} at timestamp {1:O}", Name, timestamp, dailySnapshotNeeded ? "" : "not " );
+
         return dailySnapshotNeeded;
     }
 
     /// <summary>
-    ///     Gets whether a frequent snapshot is needed, according to the provided <see cref="SnapshotTimingSettings" /> and
-    ///     <paramref name="timestamp" />
+    ///     Gets whether a frequent snapshot is needed, according to the provided <see cref="SnapshotTimingSettings"/> and
+    ///     <paramref name="timestamp"/>
     /// </summary>
     /// <param name="template">
-    ///     The <see cref="SnapshotTimingSettings" /> object to check status against.
+    ///     The <see cref="SnapshotTimingSettings"/> object to check status against.
     /// </param>
     /// <param name="timestamp">
-    ///     The <see cref="DateTimeOffset" /> value to check against the last known snapshot of this type
+    ///     The <see cref="DateTimeOffset"/> value to check against the last known snapshot of this type
     /// </param>
     /// <returns>
-    ///     A <see langword="bool" /> indicating whether ALL of the following conditions are met:
+    ///     A <see langword="bool"/> indicating whether ALL of the following conditions are met:
     ///     <list type="bullet">
     ///         <item>
     ///             <description>Template snapshot retention settings define frequent greater than 0</description>
     ///         </item>
     ///         <item>
     ///             <description>
-    ///                 <paramref name="timestamp" /> is either more than FrequentPeriod minutes ahead of the last frequent
+    ///                 <paramref name="timestamp"/> is either more than FrequentPeriod minutes ahead of the last frequent
     ///                 snapshot OR the last frequent snapshot is not in the same period of the hour
     ///             </description>
     ///         </item>
     ///     </list>
     /// </returns>
-    public bool IsFrequentSnapshotNeeded( SnapshotTimingSettings template, in DateTimeOffset timestamp )
+    public bool IsFrequentSnapshotNeeded ( SnapshotTimingSettings template, in DateTimeOffset timestamp )
     {
         //Exit early if retention settings say no frequent
-        if ( !SnapshotRetentionFrequent.IsWanted( ) )
+        if ( !SnapshotRetentionFrequent.IsWanted ( ) )
         {
             return false;
         }
 
-        Logger.Trace( "Checking if frequent snapshot is needed for dataset {0} at timestamp {1:O}", Name, timestamp );
+        Logger.Trace ( "Checking if frequent snapshot is needed for dataset {0} at timestamp {1:O}", Name, timestamp );
+
         if ( timestamp < LastFrequentSnapshotTimestamp.Value )
         {
             return false;
         }
 
-        int currentFrequentPeriodOfHour = template.GetPeriodOfHour( timestamp );
-        int lastFrequentSnapshotPeriodOfHour = template.GetPeriodOfHour( LastFrequentSnapshotTimestamp.Value );
+        int    currentFrequentPeriodOfHour      = template.GetPeriodOfHour ( timestamp );
+        int    lastFrequentSnapshotPeriodOfHour = template.GetPeriodOfHour ( LastFrequentSnapshotTimestamp.Value );
         double minutesSinceLastFrequentSnapshot = ( timestamp - LastFrequentSnapshotTimestamp.Value ).TotalMinutes;
+
         // Check if more than FrequentPeriod ago or if the period of the hour is different.
         bool frequentSnapshotNeeded = minutesSinceLastFrequentSnapshot >= template.FrequentPeriod || lastFrequentSnapshotPeriodOfHour != currentFrequentPeriodOfHour;
-        Logger.Debug( "Frequent snapshot is {2}needed for dataset {0} at timestamp {1:O}", Name, timestamp, frequentSnapshotNeeded ? "" : "not " );
+        Logger.Debug ( "Frequent snapshot is {2}needed for dataset {0} at timestamp {1:O}", Name, timestamp, frequentSnapshotNeeded ? "" : "not " );
+
         return frequentSnapshotNeeded;
     }
 
     /// <summary>
-    ///     Gets whether an hourly snapshot is needed, according to the provided <paramref name="timestamp" />
+    ///     Gets whether an hourly snapshot is needed, according to the provided <paramref name="timestamp"/>
     /// </summary>
     /// <param name="timestamp">
-    ///     The <see cref="DateTimeOffset" /> value to check against the last known snapshot of this type
+    ///     The <see cref="DateTimeOffset"/> value to check against the last known snapshot of this type
     /// </param>
     /// <returns>
-    ///     A <see langword="bool" /> indicating whether ALL of the following conditions are met:
+    ///     A <see langword="bool"/> indicating whether ALL of the following conditions are met:
     ///     <list type="bullet">
     ///         <item>
     ///             <description>Snapshot retention settings define hourly greater than 0</description>
     ///         </item>
     ///         <item>
     ///             <description>
-    ///                 <paramref name="timestamp" /> is either more than one hour ahead of the last hourly
+    ///                 <paramref name="timestamp"/> is either more than one hour ahead of the last hourly
     ///                 snapshot OR the last hourly snapshot is not in the same hour
     ///             </description>
     ///         </item>
     ///     </list>
     /// </returns>
-    public bool IsHourlySnapshotNeeded( in DateTimeOffset timestamp )
+    public bool IsHourlySnapshotNeeded ( in DateTimeOffset timestamp )
     {
         //Exit early if retention settings say no hourlies
-        if ( !SnapshotRetentionHourly.IsWanted( ) )
+        if ( !SnapshotRetentionHourly.IsWanted ( ) )
         {
             return false;
         }
 
         // Yes, this can all be done in-line, but this is easier to debug, is more explicit, and the compiler is
         // going to optimize it all away anyway.
-        Logger.Trace( "Checking if hourly snapshot is needed for dataset {0} at timestamp {1:O}", Name, timestamp );
+        Logger.Trace ( "Checking if hourly snapshot is needed for dataset {0} at timestamp {1:O}", Name, timestamp );
+
         if ( timestamp < LastHourlySnapshotTimestamp.Value )
         {
             return false;
         }
 
-        TimeSpan timeSinceLastHourlySnapshot = timestamp - LastHourlySnapshotTimestamp.Value;
-        bool atLeastOneHourSinceLastHourlySnapshot = timeSinceLastHourlySnapshot.TotalHours >= 1d;
+        TimeSpan timeSinceLastHourlySnapshot           = timestamp - LastHourlySnapshotTimestamp.Value;
+        bool     atLeastOneHourSinceLastHourlySnapshot = timeSinceLastHourlySnapshot.TotalHours >= 1d;
+
         // Check if more than an hour ago or if hour is different
         bool hourlySnapshotNeeded = atLeastOneHourSinceLastHourlySnapshot
-                                    || LastHourlySnapshotTimestamp.Value.LocalDateTime.Hour != timestamp.LocalDateTime.Hour;
-        Logger.Debug( "Hourly snapshot is {2}needed for dataset {0} at timestamp {1:O}", Name, timestamp, hourlySnapshotNeeded ? "" : "not " );
+                                 || LastHourlySnapshotTimestamp.Value.LocalDateTime.Hour != timestamp.LocalDateTime.Hour;
+        Logger.Debug ( "Hourly snapshot is {2}needed for dataset {0} at timestamp {1:O}", Name, timestamp, hourlySnapshotNeeded ? "" : "not " );
+
         return hourlySnapshotNeeded;
     }
 
@@ -760,17 +888,17 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
     ///     Gets whether a monthly snapshot is needed
     /// </summary>
     /// <param name="timestamp">
-    ///     The <see cref="DateTimeOffset" /> value to check against the last known snapshot of this type
+    ///     The <see cref="DateTimeOffset"/> value to check against the last known snapshot of this type
     /// </param>
     /// <returns>
-    ///     A <see langword="bool" /> indicating whether ALL of the following conditions are met:
+    ///     A <see langword="bool"/> indicating whether ALL of the following conditions are met:
     ///     <list type="bullet">
     ///         <item>
     ///             <description>Snapshot retention settings define monthly greater than 0</description>
     ///         </item>
     ///         <item>
     ///             <description>
-    ///                 <paramref name="timestamp" /> is either in a different month than the last monthly snapshot OR the last
+    ///                 <paramref name="timestamp"/> is either in a different month than the last monthly snapshot OR the last
     ///                 monthly snapshot is in a different year
     ///             </description>
     ///         </item>
@@ -779,53 +907,56 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
     /// <remarks>
     ///     Uses culture-aware definitions of months, using the executing user's culture.
     /// </remarks>
-    public bool IsMonthlySnapshotNeeded( in DateTimeOffset timestamp )
+    public bool IsMonthlySnapshotNeeded ( in DateTimeOffset timestamp )
     {
         //Exit early if retention settings say no monthlies
-        if ( !SnapshotRetentionMonthly.IsWanted( ) )
+        if ( !SnapshotRetentionMonthly.IsWanted ( ) )
         {
             return false;
         }
 
         // Yes, this can all be done in-line, but this is easier to debug, is more explicit, and the compiler is
         // going to optimize it all away anyway.
-        Logger.Trace( "Checking if monthly snapshot is needed for dataset {0} at timestamp {1:O}", Name, timestamp );
+        Logger.Trace ( "Checking if monthly snapshot is needed for dataset {0} at timestamp {1:O}", Name, timestamp );
+
         if ( timestamp < LastMonthlySnapshotTimestamp.Value )
         {
             return false;
         }
 
-        int lastMonthlySnapshotMonth = CultureInfo.CurrentCulture.Calendar.GetMonth( LastMonthlySnapshotTimestamp.Value.LocalDateTime );
-        int currentMonth = CultureInfo.CurrentCulture.Calendar.GetMonth( timestamp.LocalDateTime );
-        int lastMonthlySnapshotYear = CultureInfo.CurrentCulture.Calendar.GetYear( LastMonthlySnapshotTimestamp.Value.LocalDateTime );
-        int currentYear = CultureInfo.CurrentCulture.Calendar.GetYear( timestamp.LocalDateTime );
+        int lastMonthlySnapshotMonth = CultureInfo.CurrentCulture.Calendar.GetMonth ( LastMonthlySnapshotTimestamp.Value.LocalDateTime );
+        int currentMonth             = CultureInfo.CurrentCulture.Calendar.GetMonth ( timestamp.LocalDateTime );
+        int lastMonthlySnapshotYear  = CultureInfo.CurrentCulture.Calendar.GetYear ( LastMonthlySnapshotTimestamp.Value.LocalDateTime );
+        int currentYear              = CultureInfo.CurrentCulture.Calendar.GetYear ( timestamp.LocalDateTime );
+
         // Check if the last monthly snapshot was in a different month or if same month but different year
         bool lastMonthlySnapshotInDifferentMonth = lastMonthlySnapshotMonth != currentMonth;
-        bool lastMonthlySnapshotInDifferentYear = currentYear != lastMonthlySnapshotYear;
-        bool monthlySnapshotNeeded = lastMonthlySnapshotInDifferentMonth || lastMonthlySnapshotInDifferentYear;
-        Logger.Debug( "Monthly snapshot is {2}needed for dataset {0} at timestamp {1:O}", Name, timestamp, monthlySnapshotNeeded ? "" : "not " );
+        bool lastMonthlySnapshotInDifferentYear  = currentYear              != lastMonthlySnapshotYear;
+        bool monthlySnapshotNeeded               = lastMonthlySnapshotInDifferentMonth || lastMonthlySnapshotInDifferentYear;
+        Logger.Debug ( "Monthly snapshot is {2}needed for dataset {0} at timestamp {1:O}", Name, timestamp, monthlySnapshotNeeded ? "" : "not " );
+
         return monthlySnapshotNeeded;
     }
 
     /// <summary>
-    ///     Gets whether a weekly snapshot is needed, according to the provided <see cref="SnapshotTimingSettings" /> and
-    ///     <paramref name="timestamp" />
+    ///     Gets whether a weekly snapshot is needed, according to the provided <see cref="SnapshotTimingSettings"/> and
+    ///     <paramref name="timestamp"/>
     /// </summary>
     /// <param name="template">
-    ///     The <see cref="SnapshotTimingSettings" /> object to check status against.
+    ///     The <see cref="SnapshotTimingSettings"/> object to check status against.
     /// </param>
     /// <param name="timestamp">
-    ///     The <see cref="DateTimeOffset" /> value to check against the last known snapshot of this type
+    ///     The <see cref="DateTimeOffset"/> value to check against the last known snapshot of this type
     /// </param>
     /// <returns>
-    ///     A <see langword="bool" /> indicating whether ALL of the following conditions are met:
+    ///     A <see langword="bool"/> indicating whether ALL of the following conditions are met:
     ///     <list type="bullet">
     ///         <item>
     ///             <description>Snapshot retention settings define weekly greater than 0</description>
     ///         </item>
     ///         <item>
     ///             <description>
-    ///                 <paramref name="timestamp" /> is either more than 7 days ahead of the last weekly
+    ///                 <paramref name="timestamp"/> is either more than 7 days ahead of the last weekly
     ///                 snapshot OR the last weekly snapshot is not in the same week of the year
     ///             </description>
     ///         </item>
@@ -835,182 +966,191 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
     ///     Uses culture-aware definitions of week numbers, using the executing user's culture, and treating the day of the
     ///     week specified in settings for weekly snapshots as the "first" day of the week, for week numbering purposes
     /// </remarks>
-    public bool IsWeeklySnapshotNeeded( SnapshotTimingSettings template, in DateTimeOffset timestamp )
+    public bool IsWeeklySnapshotNeeded ( SnapshotTimingSettings template, in DateTimeOffset timestamp )
     {
         //Exit early if retention settings say no weeklies
-        if ( !SnapshotRetentionWeekly.IsWanted( ) )
+        if ( !SnapshotRetentionWeekly.IsWanted ( ) )
         {
-            Logger.Debug( "Weekly snapshot not wanted for {0} {1}", Kind, Name );
+            Logger.Debug ( "Weekly snapshot not wanted for {0} {1}", Kind, Name );
+
             return false;
         }
 
-        Logger.Trace( "Checking if weekly snapshot is needed for dataset {0} at timestamp {1:O}", Name, timestamp );
+        Logger.Trace ( "Checking if weekly snapshot is needed for dataset {0} at timestamp {1:O}", Name, timestamp );
+
         if ( timestamp < LastWeeklySnapshotTimestamp.Value )
         {
-            Logger.Debug( "Weekly snapshot not needed for {0} {1}", Kind, Name );
+            Logger.Debug ( "Weekly snapshot not needed for {0} {1}", Kind, Name );
+
             return false;
         }
 
-        TimeSpan timeSinceLastWeeklySnapshot = timestamp - LastWeeklySnapshotTimestamp.Value;
-        bool atLeastOneWeekSinceLastWeeklySnapshot = timeSinceLastWeeklySnapshot.TotalDays >= 7d;
+        TimeSpan timeSinceLastWeeklySnapshot           = timestamp - LastWeeklySnapshotTimestamp.Value;
+        bool     atLeastOneWeekSinceLastWeeklySnapshot = timeSinceLastWeeklySnapshot.TotalDays >= 7d;
+
         // Check if more than a week ago or if the week number is different by local rules, using the chosen day as the first day of the week
-        int lastWeeklySnapshotWeekNumber = CultureInfo.CurrentCulture.Calendar.GetWeekOfYear( LastWeeklySnapshotTimestamp.Value.LocalDateTime, CalendarWeekRule.FirstDay, template.WeeklyDay );
-        int currentWeekNumber = CultureInfo.CurrentCulture.Calendar.GetWeekOfYear( timestamp.LocalDateTime, CalendarWeekRule.FirstDay, template.WeeklyDay );
-        bool weeklySnapshotNeeded = atLeastOneWeekSinceLastWeeklySnapshot || currentWeekNumber != lastWeeklySnapshotWeekNumber;
-        Logger.Debug( "Weekly snapshot is {2}needed for dataset {0} at timestamp {1:O}", Name, timestamp, weeklySnapshotNeeded ? "" : "not " );
+        int  lastWeeklySnapshotWeekNumber = CultureInfo.CurrentCulture.Calendar.GetWeekOfYear ( LastWeeklySnapshotTimestamp.Value.LocalDateTime, CalendarWeekRule.FirstDay, template.WeeklyDay );
+        int  currentWeekNumber            = CultureInfo.CurrentCulture.Calendar.GetWeekOfYear ( timestamp.LocalDateTime,                         CalendarWeekRule.FirstDay, template.WeeklyDay );
+        bool weeklySnapshotNeeded         = atLeastOneWeekSinceLastWeeklySnapshot || currentWeekNumber != lastWeeklySnapshotWeekNumber;
+        Logger.Debug ( "Weekly snapshot is {2}needed for dataset {0} at timestamp {1:O}", Name, timestamp, weeklySnapshotNeeded ? "" : "not " );
+
         return weeklySnapshotNeeded;
     }
 
     /// <summary>
-    ///     Gets whether a yearly snapshot is needed, according to the <paramref name="timestamp" /> and properties defined on
-    ///     the <see cref="ZfsRecord" />
+    ///     Gets whether a yearly snapshot is needed, according to the <paramref name="timestamp"/> and properties defined on
+    ///     the <see cref="ZfsRecord"/>
     /// </summary>
     /// <param name="timestamp">
-    ///     The <see cref="DateTimeOffset" /> value to check against the last known snapshot of this type
+    ///     The <see cref="DateTimeOffset"/> value to check against the last known snapshot of this type
     /// </param>
     /// <returns>
-    ///     A <see langword="bool" /> indicating whether the last yearly snapshot is in the same year as
-    ///     <paramref name="timestamp" />
+    ///     A <see langword="bool"/> indicating whether the last yearly snapshot is in the same year as
+    ///     <paramref name="timestamp"/>
     /// </returns>
     /// <remarks>
     ///     Uses culture-aware definitions of years, using the executing user's culture.
     /// </remarks>
-    public bool IsYearlySnapshotNeeded( in DateTimeOffset timestamp )
+    public bool IsYearlySnapshotNeeded ( in DateTimeOffset timestamp )
     {
         //Exit early if retention settings say no monthlies
-        if ( !SnapshotRetentionYearly.IsWanted( ) )
+        if ( !SnapshotRetentionYearly.IsWanted ( ) )
         {
             return false;
         }
 
         // Yes, this can all be done in-line, but this is easier to debug, is more explicit, and the compiler is
         // going to optimize it all away anyway.
-        Logger.Trace( "Checking if yearly snapshot is needed for dataset {0} at timestamp {1:O}", Name, timestamp );
+        Logger.Trace ( "Checking if yearly snapshot is needed for dataset {0} at timestamp {1:O}", Name, timestamp );
+
         if ( timestamp < LastYearlySnapshotTimestamp.Value )
         {
             return false;
         }
 
-        int lastYearlySnapshotYear = CultureInfo.CurrentCulture.Calendar.GetYear( LastYearlySnapshotTimestamp.Value.LocalDateTime );
-        int currentYear = CultureInfo.CurrentCulture.Calendar.GetYear( timestamp.LocalDateTime );
+        int lastYearlySnapshotYear = CultureInfo.CurrentCulture.Calendar.GetYear ( LastYearlySnapshotTimestamp.Value.LocalDateTime );
+        int currentYear            = CultureInfo.CurrentCulture.Calendar.GetYear ( timestamp.LocalDateTime );
+
         // Check if the last yearly snapshot was in a different year
         bool yearlySnapshotNeeded = lastYearlySnapshotYear < currentYear;
-        Logger.Debug( "Yearly snapshot is {2}needed for dataset {0} at timestamp {1:O}", Name, timestamp, yearlySnapshotNeeded ? "" : "not " );
+        Logger.Debug ( "Yearly snapshot is {2}needed for dataset {0} at timestamp {1:O}", Name, timestamp, yearlySnapshotNeeded ? "" : "not " );
+
         return yearlySnapshotNeeded;
     }
 
-    public bool RemoveSnapshot( Snapshot snapshot )
+    public bool RemoveSnapshot ( Snapshot snapshot )
     {
-        Logger.Debug( "Removing snapshot {0} from {1}", snapshot.Name, Name );
-        UnsubscribeSnapshotFromPropertyEvents( snapshot );
-        return Snapshots[ snapshot.Period.Value.ToSnapshotPeriodKind( ) ].TryRemove( snapshot.Name, out _ );
+        Logger.Debug ( "Removing snapshot {0} from {1}", snapshot.Name, Name );
+        UnsubscribeSnapshotFromPropertyEvents ( snapshot );
+
+        return Snapshots [ snapshot.Period.Value.ToSnapshotPeriodKind ( ) ].TryRemove ( snapshot.Name, out _ );
     }
 
     /// <exception cref="ArgumentNullException">
-    ///     name must be a non-null, non-empty, non-whitespace string <paramref name="name" />
+    ///     name must be a non-null, non-empty, non-whitespace string <paramref name="name"/>
     /// </exception>
-    /// <exception cref="ArgumentOutOfRangeException">If <paramref name="name" /> is longer than 255 characters (ZFS limit)</exception>
-    public static bool ValidateName( string kind, string name, Regex? validatorRegex = null )
+    /// <exception cref="ArgumentOutOfRangeException">If <paramref name="name"/> is longer than 255 characters (ZFS limit)</exception>
+    public static bool ValidateName ( string kind, string name, Regex? validatorRegex = null )
     {
-        Logger.Debug( "Validating name \"{0}\"", name );
-        if ( string.IsNullOrWhiteSpace( name ) )
+        Logger.Debug ( "Validating name \"{0}\"", name );
+
+        if ( string.IsNullOrWhiteSpace ( name ) )
         {
-            throw new ArgumentNullException( nameof( name ), "name must be a non-null, non-empty, non-whitespace string" );
+            throw new ArgumentNullException ( nameof (name), "name must be a non-null, non-empty, non-whitespace string" );
         }
 
         if ( name.Length > 255 )
         {
-            throw new ArgumentOutOfRangeException( nameof( name ), "name must be 255 characters or less" );
+            throw new ArgumentOutOfRangeException ( nameof (name), "name must be 255 characters or less" );
         }
 
         // Sure they are... They're handled by the default case.
         // ReSharper disable once SwitchExpressionHandlesSomeKnownEnumValuesWithExceptionInDefault
         validatorRegex ??= kind switch
-        {
-            ZfsPropertyValueConstants.FileSystem => ZfsIdentifierRegexes.DatasetNameRegex( ),
-            ZfsPropertyValueConstants.Volume => ZfsIdentifierRegexes.DatasetNameRegex( ),
-            ZfsPropertyValueConstants.Snapshot => ZfsIdentifierRegexes.SnapshotNameRegex( ),
-            _ => throw new ArgumentOutOfRangeException( nameof( kind ), "Unknown type of object specified to ValidateName." )
-        };
+                           {
+                               ZfsPropertyValueConstants.FileSystem => ZfsIdentifierRegexes.DatasetNameRegex ( ),
+                               ZfsPropertyValueConstants.Volume     => ZfsIdentifierRegexes.DatasetNameRegex ( ),
+                               ZfsPropertyValueConstants.Snapshot   => ZfsIdentifierRegexes.SnapshotNameRegex ( ),
+                               _                                    => throw new ArgumentOutOfRangeException ( nameof (kind), "Unknown type of object specified to ValidateName." )
+                           };
 
-        MatchCollection matches = validatorRegex.Matches( name );
+        MatchCollection matches = validatorRegex.Matches ( name );
 
         if ( matches.Count == 0 )
         {
             return false;
         }
 
-        Logger.Trace( "Checking regex matches for {0}", name );
+        Logger.Trace ( "Checking regex matches for {0}", name );
+
         // No matter which kind was specified, the pool group should exist and be a match
         for ( int matchIndex = 0; matchIndex < matches.Count; matchIndex++ )
         {
-            Match match = matches[ matchIndex ];
-            Logger.Trace( "Inspecting match {0}", match.Value );
+            Match match = matches [ matchIndex ];
+            Logger.Trace ( "Inspecting match {0}", match.Value );
+
             if ( match.Success )
             {
-                Logger.Trace( "Match successful" );
+                Logger.Trace ( "Match successful" );
+
                 continue;
             }
 
-            Logger.Error( "Name of {0} {1} is invalid", kind, name );
+            Logger.Error ( "Name of {0} {1} is invalid", kind, name );
+
             return false;
         }
 
-        Logger.Debug( "Name of {0} {1} is valid", kind, name );
+        Logger.Debug ( "Name of {0} {1} is valid", kind, name );
 
         return true;
     }
 
-    protected internal bool ValidateName( string name )
-    {
-        return ValidateName( Kind, name, NameValidatorRegex );
-    }
+    protected internal bool ValidateName ( string name ) => ValidateName ( Kind, name, NameValidatorRegex );
 
-    protected internal bool ValidateName( )
-    {
-        return ValidateName( Name );
-    }
+    protected internal bool ValidateName ( ) => ValidateName ( Name );
 
     /// <summary>
-    ///     Gets the collection of <see cref="Snapshot" />s, groups by <see cref="SnapshotPeriodKind" />
+    ///     Gets the collection of <see cref="Snapshot"/>s, groups by <see cref="SnapshotPeriodKind"/>
     /// </summary>
     /// <remarks>
-    ///     Note that this is a reference type, as are the values of this collection.<br />
-    ///     Thus, when cloning a <see cref="ZfsRecord" /> using the <see langword="with" /> operator, this collection
+    ///     Note that this is a reference type, as are the values of this collection.<br/>
+    ///     Thus, when cloning a <see cref="ZfsRecord"/> using the <see langword="with"/> operator, this collection
     ///     needs to be re-created and all of its values deep-copied manually, if unique references are needed.
     /// </remarks>
-    private static ConcurrentDictionary<SnapshotPeriodKind, ConcurrentDictionary<string, Snapshot>> GetNewSnapshotCollection( )
-    {
-        return new(
-            new Dictionary<SnapshotPeriodKind, ConcurrentDictionary<string, Snapshot>>
-            {
-                { SnapshotPeriodKind.Frequent, new ConcurrentDictionary<string, Snapshot>( ) },
-                { SnapshotPeriodKind.Hourly, new ConcurrentDictionary<string, Snapshot>( ) },
-                { SnapshotPeriodKind.Daily, new ConcurrentDictionary<string, Snapshot>( ) },
-                { SnapshotPeriodKind.Weekly, new ConcurrentDictionary<string, Snapshot>( ) },
-                { SnapshotPeriodKind.Monthly, new ConcurrentDictionary<string, Snapshot>( ) },
-                { SnapshotPeriodKind.Yearly, new ConcurrentDictionary<string, Snapshot>( ) }
-            } );
-    }
+    private static ConcurrentDictionary<SnapshotPeriodKind, ConcurrentDictionary<string, Snapshot>> GetNewSnapshotCollection ( ) =>
+        new (
+             new Dictionary<SnapshotPeriodKind, ConcurrentDictionary<string, Snapshot>>
+             {
+                 { SnapshotPeriodKind.Frequent, new ( ) },
+                 { SnapshotPeriodKind.Hourly, new ( ) },
+                 { SnapshotPeriodKind.Daily, new ( ) },
+                 { SnapshotPeriodKind.Weekly, new ( ) },
+                 { SnapshotPeriodKind.Monthly, new ( ) },
+                 { SnapshotPeriodKind.Yearly, new ( ) }
+             } );
 
-    private void GetSnapshotsToPruneForPeriod( SnapshotPeriod snapshotPeriod, int retentionValue, List<Snapshot> snapshotsToPrune )
+    private void GetSnapshotsToPruneForPeriod ( SnapshotPeriod snapshotPeriod, int retentionValue, List<Snapshot> snapshotsToPrune )
     {
-        List<Snapshot> snapshotsSetForPruning = Snapshots[ snapshotPeriod.Kind ].Where( static kvp => kvp.Value.PruneSnapshots.Value ).Select( static kvp => kvp.Value ).ToList( );
-        Logger.Trace( "{0} snapshots of {1} configured for pruning: {2}", snapshotPeriod, Name, snapshotsSetForPruning.ToCommaSeparatedSingleLineString( true ) );
+        List<Snapshot> snapshotsSetForPruning = Snapshots [ snapshotPeriod.Kind ].Where ( static kvp => kvp.Value.PruneSnapshots.Value ).Select ( static kvp => kvp.Value ).ToList ( );
+        Logger.Trace ( "{0} snapshots of {1} configured for pruning: {2}", snapshotPeriod, Name, snapshotsSetForPruning.ToCommaSeparatedSingleLineString ( true ) );
+
         if ( snapshotsSetForPruning.Count <= retentionValue )
         {
-            Logger.Trace( "Number of pruning-enabled {0} snapshots for {1} ({2}) does not exceed retention setting ({3})", snapshotPeriod.ToString( ), Name, snapshotsSetForPruning.Count.ToString( ), retentionValue.ToString( ) );
+            Logger.Trace ( "Number of pruning-enabled {0} snapshots for {1} ({2}) does not exceed retention setting ({3})", snapshotPeriod.ToString ( ), Name, snapshotsSetForPruning.Count.ToString ( ), retentionValue.ToString ( ) );
+
             return;
         }
 
         int numberToPrune = snapshotsSetForPruning.Count - retentionValue;
-        Logger.Debug( "Need to prune oldest {0} {1} snapshots from {2}", numberToPrune, snapshotPeriod, Name );
-        snapshotsSetForPruning.Sort( );
+        Logger.Debug ( "Need to prune oldest {0} {1} snapshots from {2}", numberToPrune, snapshotPeriod, Name );
+        snapshotsSetForPruning.Sort ( );
+
         for ( int i = 0; i < numberToPrune; i++ )
         {
-            Snapshot snap = snapshotsSetForPruning[ i ];
-            Logger.Trace( "Adding snapshot {0} to prune list", snap.Name );
-            snapshotsToPrune.Add( snap );
+            Snapshot snap = snapshotsSetForPruning [ i ];
+            Logger.Trace ( "Adding snapshot {0} to prune list", snap.Name );
+            snapshotsToPrune.Add ( snap );
         }
     }
 }

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
@@ -1148,12 +1148,12 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
         new (
              new Dictionary<SnapshotPeriodKind, ConcurrentDictionary<string, Snapshot>>
              {
-                 { SnapshotPeriodKind.Frequent, new ( ) },
-                 { SnapshotPeriodKind.Hourly, new ( ) },
-                 { SnapshotPeriodKind.Daily, new ( ) },
-                 { SnapshotPeriodKind.Weekly, new ( ) },
-                 { SnapshotPeriodKind.Monthly, new ( ) },
-                 { SnapshotPeriodKind.Yearly, new ( ) }
+                 { SnapshotPeriodKind.Frequent, [ ] },
+                 { SnapshotPeriodKind.Hourly, [ ] },
+                 { SnapshotPeriodKind.Daily, [ ] },
+                 { SnapshotPeriodKind.Weekly, [ ] },
+                 { SnapshotPeriodKind.Monthly, [ ] },
+                 { SnapshotPeriodKind.Yearly, [ ] }
              } );
 
     private void GetSnapshotsToPruneForPeriod ( SnapshotPeriod snapshotPeriod, int retentionValue, List<Snapshot> snapshotsToPrune )

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
@@ -36,10 +36,7 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
     /// </exception>
     public ZfsRecord ( string Name, string Kind, string sourceSystem = "", bool inheritProperties = true, ZfsRecord? parent = null )
     {
-        if ( string.IsNullOrWhiteSpace ( sourceSystem ) )
-        {
-            throw new ArgumentNullException ( nameof (sourceSystem) );
-        }
+        ArgumentException.ThrowIfNullOrWhiteSpace ( sourceSystem, nameof (sourceSystem) );
 
         this.Name     = Name;
         IsPoolRoot    = parent is null;
@@ -100,7 +97,9 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
         }
     }
 
-    /// <summary>(Protected) Creates a new instance of a <see cref="ZfsRecord"/> from all supplied properties.</summary>
+    /// <summary>
+    ///     (Protected) Creates a new instance of a <see cref="ZfsRecord"/> from all supplied properties.
+    /// </summary>
     /// <exception cref="ArgumentException">sourceSystem must have a non-null, non-whitespace-only Value</exception>
     protected ZfsRecord (
         string                         name,
@@ -335,8 +334,9 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
     }
 
     /// <summary>
-    ///     Adds a <see cref="Snapshot"/> as an immediate descendant of the current <see cref="ZfsRecord"/> and subscribes the
-    ///     descendant to events published by the current <see cref="ZfsRecord"/>.
+    ///     Adds a <see cref="Snapshot"/> as an immediate descendant of the current <see cref="ZfsRecord"/>, subscribes the
+    ///     descendant to events published by the current <see cref="ZfsRecord"/>, and updates the corresponding latest snapshot period
+    ///     timestamp on the current object if it is newer than the current value.
     /// </summary>
     /// <returns>
     ///     The same <see cref="Snapshot"/> reference that was supplied to this method in <paramref name="snap"/>.
@@ -401,6 +401,10 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
         return snap;
     }
 
+    /// <summary>
+    ///     Creates a new <see cref="Snapshot"/> from the supplied parameters, adds it as a descendant of the current
+    ///     <see cref="ZfsRecord"/> via <see cref="AddSnapshot"/>, and returns a reference to the new <see cref="Snapshot"/> instance.
+    /// </summary>
     /// <exception cref="ArgumentException">sourceSystem must have a non-null, non-whitespace-only Value</exception>
     public Snapshot CreateAndAddSnapshot (
         string                         snapName,

--- a/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
+++ b/Libraries/SnapsInAZfs.Interop/Zfs/ZfsTypes/ZfsRecord.cs
@@ -349,51 +349,32 @@ public partial record ZfsRecord : IComparable<ZfsRecord>, IEqualityOperators<Zfs
 
         switch ( periodKind )
         {
-            case SnapshotPeriodKind.Frequent:
-                if ( LastObservedFrequentSnapshotTimestamp < snap.Timestamp.Value )
-                {
-                    LastObservedFrequentSnapshotTimestamp = snap.Timestamp.Value;
-                }
-
-                break;
-            case SnapshotPeriodKind.Hourly:
-                if ( LastObservedHourlySnapshotTimestamp < snap.Timestamp.Value )
-                {
-                    LastObservedHourlySnapshotTimestamp = snap.Timestamp.Value;
-                }
-
-                break;
-            case SnapshotPeriodKind.Daily:
-                if ( LastObservedDailySnapshotTimestamp < snap.Timestamp.Value )
-                {
-                    LastObservedDailySnapshotTimestamp = snap.Timestamp.Value;
-                }
-
-                break;
-            case SnapshotPeriodKind.Weekly:
-                if ( LastObservedWeeklySnapshotTimestamp < snap.Timestamp.Value )
-                {
-                    LastObservedWeeklySnapshotTimestamp = snap.Timestamp.Value;
-                }
-
-                break;
-            case SnapshotPeriodKind.Monthly:
-                if ( LastObservedMonthlySnapshotTimestamp < snap.Timestamp.Value )
-                {
-                    LastObservedMonthlySnapshotTimestamp = snap.Timestamp.Value;
-                }
-
-                break;
-            case SnapshotPeriodKind.Yearly:
-                if ( LastObservedYearlySnapshotTimestamp < snap.Timestamp.Value )
-                {
-                    LastObservedYearlySnapshotTimestamp = snap.Timestamp.Value;
-                }
-
-                break;
-            case SnapshotPeriodKind.NotSet:
-            default:
+            case < SnapshotPeriodKind.Frequent or > SnapshotPeriodKind.Yearly:
                 throw new InvalidOperationException ( "Invalid Snapshot Period specified" );
+            case SnapshotPeriodKind.Frequent when LastObservedFrequentSnapshotTimestamp < snap.Timestamp.Value:
+                LastObservedFrequentSnapshotTimestamp = snap.Timestamp.Value;
+
+                break;
+            case SnapshotPeriodKind.Hourly when LastObservedHourlySnapshotTimestamp < snap.Timestamp.Value:
+                LastObservedHourlySnapshotTimestamp = snap.Timestamp.Value;
+
+                break;
+            case SnapshotPeriodKind.Daily when LastObservedDailySnapshotTimestamp < snap.Timestamp.Value:
+                LastObservedDailySnapshotTimestamp = snap.Timestamp.Value;
+
+                break;
+            case SnapshotPeriodKind.Weekly when LastObservedWeeklySnapshotTimestamp < snap.Timestamp.Value:
+                LastObservedWeeklySnapshotTimestamp = snap.Timestamp.Value;
+
+                break;
+            case SnapshotPeriodKind.Monthly when LastObservedMonthlySnapshotTimestamp < snap.Timestamp.Value:
+                LastObservedMonthlySnapshotTimestamp = snap.Timestamp.Value;
+
+                break;
+            case SnapshotPeriodKind.Yearly when LastObservedYearlySnapshotTimestamp < snap.Timestamp.Value:
+                LastObservedYearlySnapshotTimestamp = snap.Timestamp.Value;
+
+                break;
         }
 
         SubscribeSnapshotToPropertyEvents ( snap );

--- a/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsRecordTests/ZfsRecordTestHelpers.cs
+++ b/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsRecordTests/ZfsRecordTestHelpers.cs
@@ -230,4 +230,8 @@ public class ZfsRecordTestHelpers
         return TestContext.CurrentContext.Random.GetString( pathComponentLength, AllowedIdentifierComponentCharacters );
     }
 #pragma warning restore NUnit1028
+    public static bool BoolPropertyComparer_Force_op_Equality ( ZfsProperty<bool>                     left, ZfsProperty<bool>           right ) => left == right;
+    public static bool DateTimeOffsetPropertyComparer_Force_op_Equality ( ZfsProperty<DateTimeOffset> left, ZfsProperty<DateTimeOffset> right ) => left == right;
+    public static bool IntPropertyComparer_Force_op_Equality ( ZfsProperty<int>                       left, ZfsProperty<int>            right ) => left == right;
+    public static bool StringPropertyComparer_Force_op_Equality ( ZfsProperty<string>                 left, ZfsProperty<string>         right ) => left == right;
 }

--- a/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsRecordTests/ZfsRecordTests.Constructors.cs
+++ b/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsRecordTests/ZfsRecordTests.Constructors.cs
@@ -1,12 +1,16 @@
-// LICENSE:
+#region MIT LICENSE
+
+// Copyright 2025 Brandon Thetford
 // 
-// Copyright 2023 Brandon Thetford
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+// See https://opensource.org/license/MIT/
+
+#endregion
 
 using SnapsInAZfs.Interop.Zfs.ZfsTypes;
 using SnapsInAZfs.Interop.Zfs.ZfsTypes.Validation;
@@ -50,107 +54,113 @@ public class ZfsRecordTests_Constructors
     }
 
     [Test]
-    [Description( "Test of the constructor that can only be used to create pool root FileSystem records" )]
-    [Order( 1 )]
+    [Description ( "Test of the constructor that can only be used to create pool root FileSystem records" )]
+    [Order ( 1 )]
     [NonParallelizable]
-    [Category( "TypeChecks" )]
-    [TestCase( "testRootZfsRecord1", ZfsPropertyValueConstants.FileSystem )]
-    [TestCase( "testRootZfsRecord2", ZfsPropertyValueConstants.FileSystem )]
-    public void Constructor_ZfsRecord_Name_Kind_ExpectedPropertiesSet( string name, string kind )
+    [Category ( "TypeChecks" )]
+    [TestCase ( "testRootZfsRecord1", ZfsPropertyValueConstants.FileSystem )]
+    [TestCase ( "testRootZfsRecord2", ZfsPropertyValueConstants.FileSystem )]
+    public void Constructor_ZfsRecord_Name_Kind_ExpectedPropertiesSet ( string name, string kind )
     {
-        ZfsRecord dataset = new( name, kind, "testSystem" );
-        Assert.That( dataset, Is.Not.Null );
-        Assert.That( dataset, Is.InstanceOf<ZfsRecord>( ) );
-        Assert.Multiple( ( ) =>
-        {
-            Assert.That( dataset.Name, Is.EqualTo( name ) );
-            Assert.That( dataset.Kind, Is.EqualTo( kind ) );
-            Assert.That( dataset.ParentDataset, Is.SameAs( dataset ) );
-            Assert.That( dataset.IsPoolRoot, Is.True );
-            Assert.That( dataset.NameValidatorRegex, Is.SameAs( ZfsIdentifierRegexes.DatasetNameRegex( ) ) );
-            Assert.That( dataset.BytesAvailable, Is.Zero );
-            Assert.That( dataset.BytesUsed, Is.Zero );
-            Assert.That( dataset.Enabled, Is.EqualTo( new ZfsProperty<bool>( dataset, ZfsPropertyNames.EnabledPropertyName, false ) ) );
-            Assert.That( dataset.LastDailySnapshotTimestamp, Is.EqualTo( new ZfsProperty<DateTimeOffset>( dataset, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-            Assert.That( dataset.LastFrequentSnapshotTimestamp, Is.EqualTo( new ZfsProperty<DateTimeOffset>( dataset, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-            Assert.That( dataset.LastHourlySnapshotTimestamp, Is.EqualTo( new ZfsProperty<DateTimeOffset>( dataset, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-            Assert.That( dataset.LastMonthlySnapshotTimestamp, Is.EqualTo( new ZfsProperty<DateTimeOffset>( dataset, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-            Assert.That( dataset.LastObservedDailySnapshotTimestamp, Is.EqualTo( DateTimeOffset.UnixEpoch ) );
-            Assert.That( dataset.LastObservedFrequentSnapshotTimestamp, Is.EqualTo( DateTimeOffset.UnixEpoch ) );
-            Assert.That( dataset.LastObservedHourlySnapshotTimestamp, Is.EqualTo( DateTimeOffset.UnixEpoch ) );
-            Assert.That( dataset.LastObservedMonthlySnapshotTimestamp, Is.EqualTo( DateTimeOffset.UnixEpoch ) );
-            Assert.That( dataset.LastObservedWeeklySnapshotTimestamp, Is.EqualTo( DateTimeOffset.UnixEpoch ) );
-            Assert.That( dataset.LastObservedYearlySnapshotTimestamp, Is.EqualTo( DateTimeOffset.UnixEpoch ) );
-            Assert.That( dataset.LastWeeklySnapshotTimestamp, Is.EqualTo( new ZfsProperty<DateTimeOffset>( dataset, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-            Assert.That( dataset.LastYearlySnapshotTimestamp, Is.EqualTo( new ZfsProperty<DateTimeOffset>( dataset, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-            Assert.That( dataset.PruneSnapshots, Is.EqualTo( new ZfsProperty<bool>( dataset, ZfsPropertyNames.PruneSnapshotsPropertyName, false ) ) );
-            Assert.That( dataset.Recursion, Is.EqualTo( new ZfsProperty<string>( dataset, ZfsPropertyNames.RecursionPropertyName, ZfsPropertyValueConstants.SnapsInAZfs ) ) );
-            Assert.That( dataset.SnapshotRetentionDaily, Is.EqualTo( new ZfsProperty<int>( dataset, ZfsPropertyNames.SnapshotRetentionDailyPropertyName, -1 ) ) );
-            Assert.That( dataset.SnapshotRetentionFrequent, Is.EqualTo( new ZfsProperty<int>( dataset, ZfsPropertyNames.SnapshotRetentionFrequentPropertyName, -1 ) ) );
-            Assert.That( dataset.SnapshotRetentionHourly, Is.EqualTo( new ZfsProperty<int>( dataset, ZfsPropertyNames.SnapshotRetentionHourlyPropertyName, -1 ) ) );
-            Assert.That( dataset.SnapshotRetentionMonthly, Is.EqualTo( new ZfsProperty<int>( dataset, ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName, -1 ) ) );
-            Assert.That( dataset.SnapshotRetentionPruneDeferral, Is.EqualTo( new ZfsProperty<int>( dataset, ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, 0 ) ) );
-            Assert.That( dataset.SnapshotRetentionWeekly, Is.EqualTo( new ZfsProperty<int>( dataset, ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName, -1 ) ) );
-            Assert.That( dataset.SnapshotRetentionYearly, Is.EqualTo( new ZfsProperty<int>( dataset, ZfsPropertyNames.SnapshotRetentionYearlyPropertyName, -1 ) ) );
-            Assert.That( dataset.TakeSnapshots, Is.EqualTo( new ZfsProperty<bool>( dataset, ZfsPropertyNames.TakeSnapshotsPropertyName, false ) ) );
-            Assert.That( dataset.Template, Is.EqualTo( new ZfsProperty<string>( dataset, ZfsPropertyNames.TemplatePropertyName, ZfsPropertyValueConstants.Default ) ) );
-        } );
+        ZfsRecord dataset = new ( name, kind, "testSystem" );
+        Assert.That ( dataset, Is.Not.Null );
+        Assert.That ( dataset, Is.InstanceOf<ZfsRecord> ( ) );
+
+        Assert.Multiple (
+                         ( ) =>
+                         {
+                             Assert.That ( dataset.Name,                                  Is.EqualTo ( name ) );
+                             Assert.That ( dataset.Kind,                                  Is.EqualTo ( kind ) );
+                             Assert.That ( dataset.ParentDataset,                         Is.SameAs ( dataset ) );
+                             Assert.That ( dataset.IsPoolRoot,                            Is.True );
+                             Assert.That ( dataset.NameValidatorRegex,                    Is.SameAs ( ZfsIdentifierRegexes.DatasetNameRegex ( ) ) );
+                             Assert.That ( dataset.BytesAvailable,                        Is.Zero );
+                             Assert.That ( dataset.BytesUsed,                             Is.Zero );
+                             Assert.That ( dataset.Enabled,                               Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.EnabledPropertyName, false ) ) );
+                             Assert.That ( dataset.LastDailySnapshotTimestamp,            Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName,    DateTimeOffset.UnixEpoch ) ) );
+                             Assert.That ( dataset.LastFrequentSnapshotTimestamp,         Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
+                             Assert.That ( dataset.LastHourlySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName,   DateTimeOffset.UnixEpoch ) ) );
+                             Assert.That ( dataset.LastMonthlySnapshotTimestamp,          Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName,  DateTimeOffset.UnixEpoch ) ) );
+                             Assert.That ( dataset.LastObservedDailySnapshotTimestamp,    Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
+                             Assert.That ( dataset.LastObservedFrequentSnapshotTimestamp, Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
+                             Assert.That ( dataset.LastObservedHourlySnapshotTimestamp,   Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
+                             Assert.That ( dataset.LastObservedMonthlySnapshotTimestamp,  Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
+                             Assert.That ( dataset.LastObservedWeeklySnapshotTimestamp,   Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
+                             Assert.That ( dataset.LastObservedYearlySnapshotTimestamp,   Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
+                             Assert.That ( dataset.LastWeeklySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
+                             Assert.That ( dataset.LastYearlySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
+                             Assert.That ( dataset.PruneSnapshots,                        Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.PruneSnapshotsPropertyName, false ) ) );
+                             Assert.That ( dataset.Recursion,                             Is.EqualTo ( new ZfsProperty<string> ( dataset, ZfsPropertyNames.RecursionPropertyName, ZfsPropertyValueConstants.SnapsInAZfs ) ) );
+                             Assert.That ( dataset.SnapshotRetentionDaily,                Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionDailyPropertyName,         -1 ) ) );
+                             Assert.That ( dataset.SnapshotRetentionFrequent,             Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionFrequentPropertyName,      -1 ) ) );
+                             Assert.That ( dataset.SnapshotRetentionHourly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionHourlyPropertyName,        -1 ) ) );
+                             Assert.That ( dataset.SnapshotRetentionMonthly,              Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName,       -1 ) ) );
+                             Assert.That ( dataset.SnapshotRetentionPruneDeferral,        Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, 0 ) ) );
+                             Assert.That ( dataset.SnapshotRetentionWeekly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName,        -1 ) ) );
+                             Assert.That ( dataset.SnapshotRetentionYearly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionYearlyPropertyName,        -1 ) ) );
+                             Assert.That ( dataset.TakeSnapshots,                         Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.TakeSnapshotsPropertyName, false ) ) );
+                             Assert.That ( dataset.Template,                              Is.EqualTo ( new ZfsProperty<string> ( dataset, ZfsPropertyNames.TemplatePropertyName, ZfsPropertyValueConstants.Default ) ) );
+                         } );
     }
 
     [Test]
-    [Order( 2 )]
+    [Order ( 2 )]
     [NonParallelizable]
-    [Category( "TypeChecks" )]
-    [TestCase( "testRootZfsRecord1/ChildFs1", ZfsPropertyValueConstants.FileSystem, "testRootZfsRecord1" )]
-    [TestCase( "testRootZfsRecord1/ChildVol1", ZfsPropertyValueConstants.Volume, "testRootZfsRecord1" )]
-    [TestCase( "testRootZfsRecord2/ChildFs1", ZfsPropertyValueConstants.FileSystem, "testRootZfsRecord2" )]
-    [TestCase( "testRootZfsRecord2/ChildVol1", ZfsPropertyValueConstants.Volume, "testRootZfsRecord2" )]
-    public void Constructor_ZfsRecord_Name_Kind_Parent_ExpectedPropertiesSet( string name, string kind, string parentName )
+    [Category ( "TypeChecks" )]
+    [TestCase ( "testRootZfsRecord1/ChildFs1",  ZfsPropertyValueConstants.FileSystem, "testRootZfsRecord1" )]
+    [TestCase ( "testRootZfsRecord1/ChildVol1", ZfsPropertyValueConstants.Volume,     "testRootZfsRecord1" )]
+    [TestCase ( "testRootZfsRecord2/ChildFs1",  ZfsPropertyValueConstants.FileSystem, "testRootZfsRecord2" )]
+    [TestCase ( "testRootZfsRecord2/ChildVol1", ZfsPropertyValueConstants.Volume,     "testRootZfsRecord2" )]
+    public void Constructor_ZfsRecord_Name_Kind_Parent_ExpectedPropertiesSet ( string name, string kind, string parentName )
     {
-        ZfsRecord parentDataset = new( parentName, ZfsPropertyValueConstants.FileSystem, "testSystem" );
-        Assume.That( parentDataset, Is.Not.Null );
-        Assume.That( parentDataset, Is.TypeOf<ZfsRecord>( ) );
-        ZfsRecord dataset = new( name, kind, "testSystem", true, parentDataset );
-        Assert.Multiple( ( ) =>
-        {
-            Assert.That( dataset, Is.Not.Null );
-            Assert.That( dataset, Is.InstanceOf<ZfsRecord>( ) );
-        } );
-        Assert.Multiple( ( ) =>
-        {
-            Assert.That( dataset.Name, Is.EqualTo( name ) );
-            Assert.That( dataset.Kind, Is.EqualTo( kind ) );
-            Assert.That( dataset.ParentDataset, Is.SameAs( parentDataset ) );
-            Assert.That( dataset.IsPoolRoot, Is.False );
-            Assert.That( dataset.NameValidatorRegex, Is.SameAs( ZfsIdentifierRegexes.DatasetNameRegex( ) ) );
-            Assert.That( dataset.BytesAvailable, Is.Zero );
-            Assert.That( dataset.BytesUsed, Is.Zero );
+        ZfsRecord parentDataset = new ( parentName, ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        Assume.That ( parentDataset, Is.Not.Null );
+        Assume.That ( parentDataset, Is.TypeOf<ZfsRecord> ( ) );
+        ZfsRecord dataset = new ( name, kind, "testSystem", true, parentDataset );
+
+        Assert.Multiple (
+                         ( ) =>
+                         {
+                             Assert.That ( dataset, Is.Not.Null );
+                             Assert.That ( dataset, Is.InstanceOf<ZfsRecord> ( ) );
+                         } );
+
+        Assert.Multiple (
+                         ( ) =>
+                         {
+                             Assert.That ( dataset.Name,               Is.EqualTo ( name ) );
+                             Assert.That ( dataset.Kind,               Is.EqualTo ( kind ) );
+                             Assert.That ( dataset.ParentDataset,      Is.SameAs ( parentDataset ) );
+                             Assert.That ( dataset.IsPoolRoot,         Is.False );
+                             Assert.That ( dataset.NameValidatorRegex, Is.SameAs ( ZfsIdentifierRegexes.DatasetNameRegex ( ) ) );
+                             Assert.That ( dataset.BytesAvailable,     Is.Zero );
+                             Assert.That ( dataset.BytesUsed,          Is.Zero );
 #pragma warning disable NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
-            Assert.That( dataset.Enabled.Equals( new ZfsProperty<bool>( dataset, ZfsPropertyNames.EnabledPropertyName, false, false ) ), Is.True );
+                             Assert.That ( dataset.Enabled.Equals ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.EnabledPropertyName, false, false ) ), Is.True );
 #pragma warning restore NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
-            Assert.That( dataset.LastDailySnapshotTimestamp, Is.EqualTo( new ZfsProperty<DateTimeOffset>( dataset, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-            Assert.That( dataset.LastFrequentSnapshotTimestamp, Is.EqualTo( new ZfsProperty<DateTimeOffset>( dataset, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-            Assert.That( dataset.LastHourlySnapshotTimestamp, Is.EqualTo( new ZfsProperty<DateTimeOffset>( dataset, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-            Assert.That( dataset.LastMonthlySnapshotTimestamp, Is.EqualTo( new ZfsProperty<DateTimeOffset>( dataset, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-            Assert.That( dataset.LastObservedDailySnapshotTimestamp, Is.EqualTo( DateTimeOffset.UnixEpoch ) );
-            Assert.That( dataset.LastObservedFrequentSnapshotTimestamp, Is.EqualTo( DateTimeOffset.UnixEpoch ) );
-            Assert.That( dataset.LastObservedHourlySnapshotTimestamp, Is.EqualTo( DateTimeOffset.UnixEpoch ) );
-            Assert.That( dataset.LastObservedMonthlySnapshotTimestamp, Is.EqualTo( DateTimeOffset.UnixEpoch ) );
-            Assert.That( dataset.LastObservedWeeklySnapshotTimestamp, Is.EqualTo( DateTimeOffset.UnixEpoch ) );
-            Assert.That( dataset.LastObservedYearlySnapshotTimestamp, Is.EqualTo( DateTimeOffset.UnixEpoch ) );
-            Assert.That( dataset.LastWeeklySnapshotTimestamp, Is.EqualTo( new ZfsProperty<DateTimeOffset>( dataset, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-            Assert.That( dataset.LastYearlySnapshotTimestamp, Is.EqualTo( new ZfsProperty<DateTimeOffset>( dataset, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-            Assert.That( dataset.PruneSnapshots, Is.EqualTo( new ZfsProperty<bool>( dataset, ZfsPropertyNames.PruneSnapshotsPropertyName, false, false ) ) );
-            Assert.That( dataset.Recursion, Is.EqualTo( new ZfsProperty<string>( dataset, ZfsPropertyNames.RecursionPropertyName, ZfsPropertyValueConstants.SnapsInAZfs, false ) ) );
-            Assert.That( dataset.SnapshotRetentionDaily, Is.EqualTo( new ZfsProperty<int>( dataset, ZfsPropertyNames.SnapshotRetentionDailyPropertyName, -1, false ) ) );
-            Assert.That( dataset.SnapshotRetentionFrequent, Is.EqualTo( new ZfsProperty<int>( dataset, ZfsPropertyNames.SnapshotRetentionFrequentPropertyName, -1, false ) ) );
-            Assert.That( dataset.SnapshotRetentionHourly, Is.EqualTo( new ZfsProperty<int>( dataset, ZfsPropertyNames.SnapshotRetentionHourlyPropertyName, -1, false ) ) );
-            Assert.That( dataset.SnapshotRetentionMonthly, Is.EqualTo( new ZfsProperty<int>( dataset, ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName, -1, false ) ) );
-            Assert.That( dataset.SnapshotRetentionPruneDeferral, Is.EqualTo( new ZfsProperty<int>( dataset, ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, 0, false ) ) );
-            Assert.That( dataset.SnapshotRetentionWeekly, Is.EqualTo( new ZfsProperty<int>( dataset, ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName, -1, false ) ) );
-            Assert.That( dataset.SnapshotRetentionYearly, Is.EqualTo( new ZfsProperty<int>( dataset, ZfsPropertyNames.SnapshotRetentionYearlyPropertyName, -1, false ) ) );
-            Assert.That( dataset.TakeSnapshots, Is.EqualTo( new ZfsProperty<bool>( dataset, ZfsPropertyNames.TakeSnapshotsPropertyName, false, false ) ) );
-            Assert.That( dataset.Template, Is.EqualTo( new ZfsProperty<string>( dataset, ZfsPropertyNames.TemplatePropertyName, ZfsPropertyValueConstants.Default, false ) ) );
-        } );
+                             Assert.That ( dataset.LastDailySnapshotTimestamp,            Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName,    DateTimeOffset.UnixEpoch ) ) );
+                             Assert.That ( dataset.LastFrequentSnapshotTimestamp,         Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
+                             Assert.That ( dataset.LastHourlySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName,   DateTimeOffset.UnixEpoch ) ) );
+                             Assert.That ( dataset.LastMonthlySnapshotTimestamp,          Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName,  DateTimeOffset.UnixEpoch ) ) );
+                             Assert.That ( dataset.LastObservedDailySnapshotTimestamp,    Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
+                             Assert.That ( dataset.LastObservedFrequentSnapshotTimestamp, Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
+                             Assert.That ( dataset.LastObservedHourlySnapshotTimestamp,   Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
+                             Assert.That ( dataset.LastObservedMonthlySnapshotTimestamp,  Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
+                             Assert.That ( dataset.LastObservedWeeklySnapshotTimestamp,   Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
+                             Assert.That ( dataset.LastObservedYearlySnapshotTimestamp,   Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
+                             Assert.That ( dataset.LastWeeklySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
+                             Assert.That ( dataset.LastYearlySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
+                             Assert.That ( dataset.PruneSnapshots,                        Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.PruneSnapshotsPropertyName, false, false ) ) );
+                             Assert.That ( dataset.Recursion,                             Is.EqualTo ( new ZfsProperty<string> ( dataset, ZfsPropertyNames.RecursionPropertyName, ZfsPropertyValueConstants.SnapsInAZfs, false ) ) );
+                             Assert.That ( dataset.SnapshotRetentionDaily,                Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionDailyPropertyName,         -1, false ) ) );
+                             Assert.That ( dataset.SnapshotRetentionFrequent,             Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionFrequentPropertyName,      -1, false ) ) );
+                             Assert.That ( dataset.SnapshotRetentionHourly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionHourlyPropertyName,        -1, false ) ) );
+                             Assert.That ( dataset.SnapshotRetentionMonthly,              Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName,       -1, false ) ) );
+                             Assert.That ( dataset.SnapshotRetentionPruneDeferral,        Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, 0,  false ) ) );
+                             Assert.That ( dataset.SnapshotRetentionWeekly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName,        -1, false ) ) );
+                             Assert.That ( dataset.SnapshotRetentionYearly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionYearlyPropertyName,        -1, false ) ) );
+                             Assert.That ( dataset.TakeSnapshots,                         Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.TakeSnapshotsPropertyName, false, false ) ) );
+                             Assert.That ( dataset.Template,                              Is.EqualTo ( new ZfsProperty<string> ( dataset, ZfsPropertyNames.TemplatePropertyName, ZfsPropertyValueConstants.Default, false ) ) );
+                         } );
     }
 }

--- a/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsRecordTests/ZfsRecordTests.Constructors.cs
+++ b/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsRecordTests/ZfsRecordTests.Constructors.cs
@@ -17,6 +17,8 @@ using SnapsInAZfs.Interop.Zfs.ZfsTypes.Validation;
 
 namespace SnapsInAZfs.Interop.Tests.Zfs.ZfsTypes.ZfsRecordTests;
 
+using System.Diagnostics.CodeAnalysis;
+
 [TestFixture]
 [TestOf ( typeof (ZfsRecord) )]
 [Category ( "General" )]
@@ -67,6 +69,7 @@ public class ZfsRecordTests_Constructors
         Assert.That ( dataset, Is.InstanceOf<ZfsRecord> ( ) );
 
         Assert.Multiple (
+                         [SuppressMessage ( "ReSharper", "HeapView.BoxingAllocation" )]
                          ( ) =>
                          {
                              Assert.That ( dataset.Name,                                  Is.EqualTo ( name ) );
@@ -76,30 +79,30 @@ public class ZfsRecordTests_Constructors
                              Assert.That ( dataset.NameValidatorRegex,                    Is.SameAs ( ZfsIdentifierRegexes.DatasetNameRegex ( ) ) );
                              Assert.That ( dataset.BytesAvailable,                        Is.Zero );
                              Assert.That ( dataset.BytesUsed,                             Is.Zero );
-                             Assert.That ( dataset.Enabled,                               Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.EnabledPropertyName, false ) ) );
-                             Assert.That ( dataset.LastDailySnapshotTimestamp,            Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName,    DateTimeOffset.UnixEpoch ) ) );
-                             Assert.That ( dataset.LastFrequentSnapshotTimestamp,         Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-                             Assert.That ( dataset.LastHourlySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName,   DateTimeOffset.UnixEpoch ) ) );
-                             Assert.That ( dataset.LastMonthlySnapshotTimestamp,          Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName,  DateTimeOffset.UnixEpoch ) ) );
+                             Assert.That ( dataset.Enabled,                               Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.EnabledPropertyName, false ) ).Using<ZfsProperty<bool>> ( ZfsRecordTestHelpers.BoolPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.LastDailySnapshotTimestamp,            Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName,    DateTimeOffset.UnixEpoch ) ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.LastFrequentSnapshotTimestamp,         Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.LastHourlySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName,   DateTimeOffset.UnixEpoch ) ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.LastMonthlySnapshotTimestamp,          Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName,  DateTimeOffset.UnixEpoch ) ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
                              Assert.That ( dataset.LastObservedDailySnapshotTimestamp,    Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
                              Assert.That ( dataset.LastObservedFrequentSnapshotTimestamp, Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
                              Assert.That ( dataset.LastObservedHourlySnapshotTimestamp,   Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
                              Assert.That ( dataset.LastObservedMonthlySnapshotTimestamp,  Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
                              Assert.That ( dataset.LastObservedWeeklySnapshotTimestamp,   Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
                              Assert.That ( dataset.LastObservedYearlySnapshotTimestamp,   Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
-                             Assert.That ( dataset.LastWeeklySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-                             Assert.That ( dataset.LastYearlySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-                             Assert.That ( dataset.PruneSnapshots,                        Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.PruneSnapshotsPropertyName, false ) ) );
-                             Assert.That ( dataset.Recursion,                             Is.EqualTo ( new ZfsProperty<string> ( dataset, ZfsPropertyNames.RecursionPropertyName, ZfsPropertyValueConstants.SnapsInAZfs ) ) );
-                             Assert.That ( dataset.SnapshotRetentionDaily,                Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionDailyPropertyName,         -1 ) ) );
-                             Assert.That ( dataset.SnapshotRetentionFrequent,             Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionFrequentPropertyName,      -1 ) ) );
-                             Assert.That ( dataset.SnapshotRetentionHourly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionHourlyPropertyName,        -1 ) ) );
-                             Assert.That ( dataset.SnapshotRetentionMonthly,              Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName,       -1 ) ) );
-                             Assert.That ( dataset.SnapshotRetentionPruneDeferral,        Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, 0 ) ) );
-                             Assert.That ( dataset.SnapshotRetentionWeekly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName,        -1 ) ) );
-                             Assert.That ( dataset.SnapshotRetentionYearly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionYearlyPropertyName,        -1 ) ) );
-                             Assert.That ( dataset.TakeSnapshots,                         Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.TakeSnapshotsPropertyName, false ) ) );
-                             Assert.That ( dataset.Template,                              Is.EqualTo ( new ZfsProperty<string> ( dataset, ZfsPropertyNames.TemplatePropertyName, ZfsPropertyValueConstants.Default ) ) );
+                             Assert.That ( dataset.LastWeeklySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.LastYearlySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.PruneSnapshots,                        Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.PruneSnapshotsPropertyName, false ) ).Using<ZfsProperty<bool>> ( ZfsRecordTestHelpers.BoolPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.Recursion,                             Is.EqualTo ( new ZfsProperty<string> ( dataset, ZfsPropertyNames.RecursionPropertyName, ZfsPropertyValueConstants.SnapsInAZfs ) ).Using<ZfsProperty<string>> ( ZfsRecordTestHelpers.StringPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.SnapshotRetentionDaily,                Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionDailyPropertyName,         -1 ) ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.SnapshotRetentionFrequent,             Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionFrequentPropertyName,      -1 ) ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.SnapshotRetentionHourly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionHourlyPropertyName,        -1 ) ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.SnapshotRetentionMonthly,              Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName,       -1 ) ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.SnapshotRetentionPruneDeferral,        Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, 0 ) ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.SnapshotRetentionWeekly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName,        -1 ) ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.SnapshotRetentionYearly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionYearlyPropertyName,        -1 ) ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.TakeSnapshots,                         Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.TakeSnapshotsPropertyName, false ) ).Using<ZfsProperty<bool>> ( ZfsRecordTestHelpers.BoolPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.Template,                              Is.EqualTo ( new ZfsProperty<string> ( dataset, ZfsPropertyNames.TemplatePropertyName, ZfsPropertyValueConstants.Default ) ).Using<ZfsProperty<string>> ( ZfsRecordTestHelpers.StringPropertyComparer_Force_op_Equality ) );
                          } );
     }
 
@@ -126,41 +129,40 @@ public class ZfsRecordTests_Constructors
                          } );
 
         Assert.Multiple (
+                         [SuppressMessage ( "ReSharper", "HeapView.BoxingAllocation" )]
                          ( ) =>
                          {
-                             Assert.That ( dataset.Name,               Is.EqualTo ( name ) );
-                             Assert.That ( dataset.Kind,               Is.EqualTo ( kind ) );
-                             Assert.That ( dataset.ParentDataset,      Is.SameAs ( parentDataset ) );
-                             Assert.That ( dataset.IsPoolRoot,         Is.False );
-                             Assert.That ( dataset.NameValidatorRegex, Is.SameAs ( ZfsIdentifierRegexes.DatasetNameRegex ( ) ) );
-                             Assert.That ( dataset.BytesAvailable,     Is.Zero );
-                             Assert.That ( dataset.BytesUsed,          Is.Zero );
-#pragma warning disable NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
-                             Assert.That ( dataset.Enabled.Equals ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.EnabledPropertyName, false, false ) ), Is.True );
-#pragma warning restore NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
-                             Assert.That ( dataset.LastDailySnapshotTimestamp,            Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName,    DateTimeOffset.UnixEpoch ) ) );
-                             Assert.That ( dataset.LastFrequentSnapshotTimestamp,         Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-                             Assert.That ( dataset.LastHourlySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName,   DateTimeOffset.UnixEpoch ) ) );
-                             Assert.That ( dataset.LastMonthlySnapshotTimestamp,          Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName,  DateTimeOffset.UnixEpoch ) ) );
+                             Assert.That ( dataset.Name,                                  Is.EqualTo ( name ) );
+                             Assert.That ( dataset.Kind,                                  Is.EqualTo ( kind ) );
+                             Assert.That ( dataset.ParentDataset,                         Is.SameAs ( parentDataset ) );
+                             Assert.That ( dataset.IsPoolRoot,                            Is.False );
+                             Assert.That ( dataset.NameValidatorRegex,                    Is.SameAs ( ZfsIdentifierRegexes.DatasetNameRegex ( ) ) );
+                             Assert.That ( dataset.BytesAvailable,                        Is.Zero );
+                             Assert.That ( dataset.BytesUsed,                             Is.Zero );
+                             Assert.That ( dataset.Enabled,                               Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.EnabledPropertyName, false, false ) ).Using<ZfsProperty<bool>> ( ZfsRecordTestHelpers.BoolPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.LastDailySnapshotTimestamp,            Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName,    DateTimeOffset.UnixEpoch ) ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.LastFrequentSnapshotTimestamp,         Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.LastHourlySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName,   DateTimeOffset.UnixEpoch ) ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.LastMonthlySnapshotTimestamp,          Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName,  DateTimeOffset.UnixEpoch ) ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
                              Assert.That ( dataset.LastObservedDailySnapshotTimestamp,    Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
                              Assert.That ( dataset.LastObservedFrequentSnapshotTimestamp, Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
                              Assert.That ( dataset.LastObservedHourlySnapshotTimestamp,   Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
                              Assert.That ( dataset.LastObservedMonthlySnapshotTimestamp,  Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
                              Assert.That ( dataset.LastObservedWeeklySnapshotTimestamp,   Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
                              Assert.That ( dataset.LastObservedYearlySnapshotTimestamp,   Is.EqualTo ( DateTimeOffset.UnixEpoch ) );
-                             Assert.That ( dataset.LastWeeklySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-                             Assert.That ( dataset.LastYearlySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ) );
-                             Assert.That ( dataset.PruneSnapshots,                        Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.PruneSnapshotsPropertyName, false, false ) ) );
-                             Assert.That ( dataset.Recursion,                             Is.EqualTo ( new ZfsProperty<string> ( dataset, ZfsPropertyNames.RecursionPropertyName, ZfsPropertyValueConstants.SnapsInAZfs, false ) ) );
-                             Assert.That ( dataset.SnapshotRetentionDaily,                Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionDailyPropertyName,         -1, false ) ) );
-                             Assert.That ( dataset.SnapshotRetentionFrequent,             Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionFrequentPropertyName,      -1, false ) ) );
-                             Assert.That ( dataset.SnapshotRetentionHourly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionHourlyPropertyName,        -1, false ) ) );
-                             Assert.That ( dataset.SnapshotRetentionMonthly,              Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName,       -1, false ) ) );
-                             Assert.That ( dataset.SnapshotRetentionPruneDeferral,        Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, 0,  false ) ) );
-                             Assert.That ( dataset.SnapshotRetentionWeekly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName,        -1, false ) ) );
-                             Assert.That ( dataset.SnapshotRetentionYearly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionYearlyPropertyName,        -1, false ) ) );
-                             Assert.That ( dataset.TakeSnapshots,                         Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.TakeSnapshotsPropertyName, false, false ) ) );
-                             Assert.That ( dataset.Template,                              Is.EqualTo ( new ZfsProperty<string> ( dataset, ZfsPropertyNames.TemplatePropertyName, ZfsPropertyValueConstants.Default, false ) ) );
+                             Assert.That ( dataset.LastWeeklySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.LastYearlySnapshotTimestamp,           Is.EqualTo ( new ZfsProperty<DateTimeOffset> ( dataset, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName, DateTimeOffset.UnixEpoch ) ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.PruneSnapshots,                        Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.PruneSnapshotsPropertyName, false, false ) ).Using<ZfsProperty<bool>> ( ZfsRecordTestHelpers.BoolPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.Recursion,                             Is.EqualTo ( new ZfsProperty<string> ( dataset, ZfsPropertyNames.RecursionPropertyName, ZfsPropertyValueConstants.SnapsInAZfs, false ) ).Using<ZfsProperty<string>> ( ZfsRecordTestHelpers.StringPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.SnapshotRetentionDaily,                Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionDailyPropertyName,         -1, false ) ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.SnapshotRetentionFrequent,             Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionFrequentPropertyName,      -1, false ) ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.SnapshotRetentionHourly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionHourlyPropertyName,        -1, false ) ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.SnapshotRetentionMonthly,              Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName,       -1, false ) ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.SnapshotRetentionPruneDeferral,        Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName, 0,  false ) ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.SnapshotRetentionWeekly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName,        -1, false ) ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.SnapshotRetentionYearly,               Is.EqualTo ( new ZfsProperty<int> ( dataset, ZfsPropertyNames.SnapshotRetentionYearlyPropertyName,        -1, false ) ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.TakeSnapshots,                         Is.EqualTo ( new ZfsProperty<bool> ( dataset, ZfsPropertyNames.TakeSnapshotsPropertyName, false, false ) ).Using<ZfsProperty<bool>> ( ZfsRecordTestHelpers.BoolPropertyComparer_Force_op_Equality ) );
+                             Assert.That ( dataset.Template,                              Is.EqualTo ( new ZfsProperty<string> ( dataset, ZfsPropertyNames.TemplatePropertyName, ZfsPropertyValueConstants.Default, false ) ).Using<ZfsProperty<string>> ( ZfsRecordTestHelpers.StringPropertyComparer_Force_op_Equality ) );
                          } );
     }
 }

--- a/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsRecordTests/ZfsRecordTests.Constructors.cs
+++ b/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsRecordTests/ZfsRecordTests.Constructors.cs
@@ -2,11 +2,11 @@
 // 
 // Copyright 2023 Brandon Thetford
 // 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the â€œSoftwareâ€), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED â€œAS ISâ€, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using SnapsInAZfs.Interop.Zfs.ZfsTypes;
 using SnapsInAZfs.Interop.Zfs.ZfsTypes.Validation;
@@ -14,29 +14,39 @@ using SnapsInAZfs.Interop.Zfs.ZfsTypes.Validation;
 namespace SnapsInAZfs.Interop.Tests.Zfs.ZfsTypes.ZfsRecordTests;
 
 [TestFixture]
-[TestOf( typeof( ZfsRecord ) )]
-[Category( "General" )]
-[Parallelizable( ParallelScope.Self )]
+[TestOf ( typeof (ZfsRecord) )]
+[Category ( "General" )]
+[Parallelizable ( ParallelScope.Self )]
 public class ZfsRecordTests_Constructors
 {
     [Test]
-    [Category( "General" )]
-    [Category( "TypeChecks" )]
-    [TestCase( "" )]
-    [TestCase( " " )]
-    [TestCase( "  " )]
-    [TestCase( "\t" )]
-    [TestCase( "\n" )]
-    [TestCase( "\r" )]
-    [TestCase( null, Description = "Test what happens if an external caller does not respect nullability context and gives us a null value anyway")]
-    public void Constructor_ThrowsOnSourceSystemNullEmptyOrWhitespace( string? sourceSystem )
+    [Category ( "General" )]
+    [Category ( "TypeChecks" )]
+    [TestCase ( "" )]
+    [TestCase ( " " )]
+    [TestCase ( "  " )]
+    [TestCase ( "\t" )]
+    [TestCase ( "\n" )]
+    [TestCase ( "\r" )]
+    public void Constructor_ThrowsArgumentException_OnSourceSystemEmptyOrWhitespace ( string? sourceSystem )
     {
-        Assert.That( ( ) =>
-        {
-#pragma warning disable CS8604 // Possible null reference argument - Intentional
-            ZfsRecord badRecord = new( "badRecord", ZfsPropertyValueConstants.FileSystem, sourceSystem );
-#pragma warning restore CS8604 // Possible null reference argument - Intentional
-        }, Throws.ArgumentNullException );
+        Assert.That (
+                     ( ) =>
+                     {
+                         ZfsRecord badRecord = new ( "badRecord", ZfsPropertyValueConstants.FileSystem, sourceSystem );
+                     },
+                     Throws.ArgumentException );
+    }
+
+    [Test]
+    public void Constructor_ThrowsArgumentNullException_OnSourceSystemNull ( )
+    {
+        Assert.That (
+                     static ( ) =>
+                     {
+                         ZfsRecord badRecord = new ( "badRecord", ZfsPropertyValueConstants.FileSystem, null! );
+                     },
+                     Throws.ArgumentNullException );
     }
 
     [Test]

--- a/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsRecordTests/ZfsRecordTests.cs
+++ b/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsRecordTests/ZfsRecordTests.cs
@@ -302,8 +302,8 @@ public class ZfsRecordTests
             Assert.Multiple (
                              ( ) =>
                              {
-                                 Assert.That ( updatedBoolProperty,         Is.EqualTo ( originalBoolProperty ).Using<ZfsProperty<bool>> ( BoolPropertyComparer_Force_op_Equality ) );
-                                 Assert.That ( updatedBoolProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<bool>> ( BoolPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedBoolProperty,         Is.EqualTo ( originalBoolProperty ).Using<ZfsProperty<bool>> ( ZfsRecordTestHelpers.BoolPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedBoolProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<bool>> ( ZfsRecordTestHelpers.BoolPropertyComparer_Force_op_Equality ) );
                                  Assert.That ( updatedBoolProperty.Name,    Is.EqualTo ( propertyName ) );
                                  Assert.That ( updatedBoolProperty.Value,   Is.EqualTo ( propertyValue ) );
                                  Assert.That ( updatedBoolProperty.IsLocal, Is.EqualTo ( isLocal ) );
@@ -316,8 +316,8 @@ public class ZfsRecordTests
             Assert.Multiple (
                              ( ) =>
                              {
-                                 Assert.That ( updatedBoolProperty,         Is.Not.EqualTo ( originalBoolProperty ).Using<ZfsProperty<bool>> ( BoolPropertyComparer_Force_op_Equality ) );
-                                 Assert.That ( updatedBoolProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<bool>> ( BoolPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedBoolProperty,         Is.Not.EqualTo ( originalBoolProperty ).Using<ZfsProperty<bool>> ( ZfsRecordTestHelpers.BoolPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedBoolProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<bool>> ( ZfsRecordTestHelpers.BoolPropertyComparer_Force_op_Equality ) );
                                  Assert.That ( updatedBoolProperty.Name,    Is.EqualTo ( propertyName ) );
                                  Assert.That ( updatedBoolProperty.Value,   Is.EqualTo ( propertyValue ) );
                                  Assert.That ( updatedBoolProperty.IsLocal, Is.EqualTo ( isLocal ) );
@@ -359,8 +359,8 @@ public class ZfsRecordTests
             Assert.Multiple (
                              ( ) =>
                              {
-                                 Assert.That ( updatedDateTimeOffsetProperty,         Is.EqualTo ( originalDateTimeOffsetProperty ).Using<ZfsProperty<DateTimeOffset>> ( DateTimeOffsetPropertyComparer_Force_op_Equality ) );
-                                 Assert.That ( updatedDateTimeOffsetProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<DateTimeOffset>> ( DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedDateTimeOffsetProperty,         Is.EqualTo ( originalDateTimeOffsetProperty ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedDateTimeOffsetProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
                                  Assert.That ( updatedDateTimeOffsetProperty.Name,    Is.EqualTo ( propertyName ) );
                                  Assert.That ( updatedDateTimeOffsetProperty.Value,   Is.EqualTo ( propertyValue ) );
                                  Assert.That ( updatedDateTimeOffsetProperty.IsLocal, Is.EqualTo ( isLocal ) );
@@ -373,8 +373,8 @@ public class ZfsRecordTests
             Assert.Multiple (
                              ( ) =>
                              {
-                                 Assert.That ( updatedDateTimeOffsetProperty,         Is.Not.EqualTo ( originalDateTimeOffsetProperty ).Using<ZfsProperty<DateTimeOffset>> ( DateTimeOffsetPropertyComparer_Force_op_Equality ) );
-                                 Assert.That ( updatedDateTimeOffsetProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<DateTimeOffset>> ( DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedDateTimeOffsetProperty,         Is.Not.EqualTo ( originalDateTimeOffsetProperty ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedDateTimeOffsetProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<DateTimeOffset>> ( ZfsRecordTestHelpers.DateTimeOffsetPropertyComparer_Force_op_Equality ) );
                                  Assert.That ( updatedDateTimeOffsetProperty.Name,    Is.EqualTo ( propertyName ) );
                                  Assert.That ( updatedDateTimeOffsetProperty.Value,   Is.EqualTo ( propertyValue ) );
                                  Assert.That ( updatedDateTimeOffsetProperty.IsLocal, Is.EqualTo ( isLocal ) );
@@ -415,8 +415,8 @@ public class ZfsRecordTests
             Assert.Multiple (
                              ( ) =>
                              {
-                                 Assert.That ( updatedIntProperty,         Is.EqualTo ( originalIntProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
-                                 Assert.That ( updatedIntProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedIntProperty,         Is.EqualTo ( originalIntProperty ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedIntProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
                                  Assert.That ( updatedIntProperty.Name,    Is.EqualTo ( propertyName ) );
                                  Assert.That ( updatedIntProperty.Value,   Is.EqualTo ( propertyValue ) );
                                  Assert.That ( updatedIntProperty.IsLocal, Is.EqualTo ( isLocal ) );
@@ -429,8 +429,8 @@ public class ZfsRecordTests
             Assert.Multiple (
                              ( ) =>
                              {
-                                 Assert.That ( updatedIntProperty,         Is.Not.EqualTo ( originalIntProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
-                                 Assert.That ( updatedIntProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedIntProperty,         Is.Not.EqualTo ( originalIntProperty ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedIntProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<int>> ( ZfsRecordTestHelpers.IntPropertyComparer_Force_op_Equality ) );
                                  Assert.That ( updatedIntProperty.Name,    Is.EqualTo ( propertyName ) );
                                  Assert.That ( updatedIntProperty.Value,   Is.EqualTo ( propertyValue ) );
                                  Assert.That ( updatedIntProperty.IsLocal, Is.EqualTo ( isLocal ) );
@@ -471,8 +471,8 @@ public class ZfsRecordTests
             Assert.Multiple (
                              ( ) =>
                              {
-                                 Assert.That ( updatedStringProperty,         Is.EqualTo ( originalStringProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
-                                 Assert.That ( updatedStringProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedStringProperty,         Is.EqualTo ( originalStringProperty ).Using<ZfsProperty<string>> ( ZfsRecordTestHelpers.StringPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedStringProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<string>> ( ZfsRecordTestHelpers.StringPropertyComparer_Force_op_Equality ) );
                                  Assert.That ( updatedStringProperty.Name,    Is.EqualTo ( propertyName ) );
                                  Assert.That ( updatedStringProperty.Value,   Is.EqualTo ( propertyValue ) );
                                  Assert.That ( updatedStringProperty.IsLocal, Is.EqualTo ( isLocal ) );
@@ -485,8 +485,8 @@ public class ZfsRecordTests
             Assert.Multiple (
                              ( ) =>
                              {
-                                 Assert.That ( updatedStringProperty,         Is.Not.EqualTo ( originalStringProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
-                                 Assert.That ( updatedStringProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedStringProperty,         Is.Not.EqualTo ( originalStringProperty ).Using<ZfsProperty<string>> ( ZfsRecordTestHelpers.StringPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedStringProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<string>> ( ZfsRecordTestHelpers.StringPropertyComparer_Force_op_Equality ) );
                                  Assert.That ( updatedStringProperty.Name,    Is.EqualTo ( propertyName ) );
                                  Assert.That ( updatedStringProperty.Value,   Is.EqualTo ( propertyValue ) );
                                  Assert.That ( updatedStringProperty.IsLocal, Is.EqualTo ( isLocal ) );
@@ -506,10 +506,5 @@ public class ZfsRecordTests
         }
     }
 
-    private static bool BoolPropertyComparer_Force_op_Equality ( ZfsProperty<bool>                     left, ZfsProperty<bool>           right ) => left == right;
-    private static bool DateTimeOffsetPropertyComparer_Force_op_Equality ( ZfsProperty<DateTimeOffset> left, ZfsProperty<DateTimeOffset> right ) => left == right;
-
-    private static ZfsProperty<bool> GetBoolPropertyByValueFromDataset ( ZfsRecord                  dataset, string              propertyName ) => (ZfsProperty<bool>)dataset [ propertyName ];
-    private static bool              IntPropertyComparer_Force_op_Equality ( ZfsProperty<int>       left,    ZfsProperty<int>    right )        => left == right;
-    private static bool              StringPropertyComparer_Force_op_Equality ( ZfsProperty<string> left,    ZfsProperty<string> right )        => left == right;
+    private static ZfsProperty<bool> GetBoolPropertyByValueFromDataset ( ZfsRecord dataset, string propertyName ) => (ZfsProperty<bool>)dataset [ propertyName ];
 }

--- a/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsRecordTests/ZfsRecordTests.cs
+++ b/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsRecordTests/ZfsRecordTests.cs
@@ -2,11 +2,11 @@
 // 
 // Copyright 2023 Brandon Thetford
 // 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the â€œSoftwareâ€), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED â€œAS ISâ€, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 using System.Globalization;
 using SnapsInAZfs.Interop.Tests.Zfs.ZfsTypes.SnapshotTests;
@@ -280,28 +280,29 @@ public class ZfsRecordTests
         if ( newTestCaseProperty == originalBoolProperty )
         {
             Assert.Multiple( ( ) =>
-            {
-                Assert.That( updatedBoolProperty, Is.EqualTo( originalBoolProperty ) );
-                Assert.That( updatedBoolProperty, Is.EqualTo( newTestCaseProperty ) );
-                Assert.That( updatedBoolProperty.Name, Is.EqualTo( propertyName ) );
-                Assert.That( updatedBoolProperty.Value, Is.EqualTo( propertyValue ) );
-                Assert.That( updatedBoolProperty.IsLocal, Is.EqualTo( isLocal ) );
+                             {
+                                 Assert.That ( updatedBoolProperty, Is.EqualTo ( originalBoolProperty ).Using<ZfsProperty<bool>> ( BoolPropertyComparer_Force_op_Equality ) );
+                Assert.That ( updatedBoolProperty,                  Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<bool>> ( BoolPropertyComparer_Force_op_Equality ) );
+                Assert.That( updatedBoolProperty.Name,              Is.EqualTo( propertyName ) );
+                Assert.That( updatedBoolProperty.Value,             Is.EqualTo( propertyValue ) );
+                Assert.That( updatedBoolProperty.IsLocal,           Is.EqualTo( isLocal ) );
 
                 Assert.That( updatedRecord, Is.EqualTo( originalRecord ) );
             } );
         }
         else
         {
-            Assert.Multiple( ( ) =>
-            {
-                Assert.That( updatedBoolProperty, Is.Not.EqualTo( originalBoolProperty ) );
-                Assert.That( updatedBoolProperty, Is.EqualTo( newTestCaseProperty ) );
-                Assert.That( updatedBoolProperty.Name, Is.EqualTo( propertyName ) );
-                Assert.That( updatedBoolProperty.Value, Is.EqualTo( propertyValue ) );
-                Assert.That( updatedBoolProperty.IsLocal, Is.EqualTo( isLocal ) );
+            Assert.Multiple (
+                             ( ) =>
+                             {
+                                 Assert.That ( updatedBoolProperty,         Is.Not.EqualTo ( originalBoolProperty ).Using<ZfsProperty<bool>> ( BoolPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedBoolProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<bool>> ( BoolPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedBoolProperty.Name,    Is.EqualTo ( propertyName ) );
+                                 Assert.That ( updatedBoolProperty.Value,   Is.EqualTo ( propertyValue ) );
+                                 Assert.That ( updatedBoolProperty.IsLocal, Is.EqualTo ( isLocal ) );
 
-                Assert.That( updatedRecord, Is.Not.EqualTo( originalRecord ) );
-            } );
+                                 Assert.That ( updatedRecord, Is.Not.EqualTo ( originalRecord ) );
+                             } );
         }
 
         if ( !isLocal )
@@ -316,55 +317,58 @@ public class ZfsRecordTests
 
     [Test]
     [Combinatorial]
-    public void UpdateProperty_DateTimeOffset( [Values( ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName )] string propertyName, [ValueSource( nameof( UpdateProperty_DateTimeOffset_Values ) )] string propertyValueString, [Values] bool isLocal )
+    public void UpdateProperty_DateTimeOffset ( [Values ( ZfsPropertyNames.DatasetLastFrequentSnapshotTimestampPropertyName, ZfsPropertyNames.DatasetLastHourlySnapshotTimestampPropertyName, ZfsPropertyNames.DatasetLastDailySnapshotTimestampPropertyName, ZfsPropertyNames.DatasetLastWeeklySnapshotTimestampPropertyName, ZfsPropertyNames.DatasetLastMonthlySnapshotTimestampPropertyName, ZfsPropertyNames.DatasetLastYearlySnapshotTimestampPropertyName )] string propertyName, [ValueSource ( nameof (UpdateProperty_DateTimeOffset_Values) )] string propertyValueString, [Values] bool isLocal )
     {
-        DateTimeOffset propertyValue = DateTimeOffset.ParseExact( propertyValueString, "O", DateTimeFormatInfo.CurrentInfo );
-        ZfsRecord originalParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem( );
-        ZfsRecord originalRecord = originalParent.CreateChildDataset( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
-        ZfsRecord updatedParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem( );
-        ZfsRecord updatedRecord = updatedParent.CreateChildDataset( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
-        ZfsProperty<DateTimeOffset> newTestCaseProperty = new( originalRecord, propertyName, propertyValue, isLocal );
-        ZfsProperty<DateTimeOffset> originalDateTimeOffsetProperty = (ZfsProperty<DateTimeOffset>)originalRecord[ propertyName ];
+        DateTimeOffset              propertyValue                  = DateTimeOffset.ParseExact ( propertyValueString, "O", DateTimeFormatInfo.CurrentInfo );
+        ZfsRecord                   originalParent                 = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( );
+        ZfsRecord                   originalRecord                 = originalParent.CreateChildDataset ( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsRecord                   updatedParent                  = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( );
+        ZfsRecord                   updatedRecord                  = updatedParent.CreateChildDataset ( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsProperty<DateTimeOffset> newTestCaseProperty            = new ( originalRecord, propertyName, propertyValue, isLocal );
+        ZfsProperty<DateTimeOffset> originalDateTimeOffsetProperty = (ZfsProperty<DateTimeOffset>)originalRecord [ propertyName ];
 
-        Assume.That( updatedRecord, Is.EqualTo( originalRecord ), "Both records must be identical for this test to be valid" );
-        Assume.That( updatedRecord, Is.Not.SameAs( originalRecord ) );
+        Assume.That ( updatedRecord, Is.EqualTo ( originalRecord ), "Both records must be identical for this test to be valid" );
+        Assume.That ( updatedRecord, Is.Not.SameAs ( originalRecord ) );
 
-        ZfsProperty<DateTimeOffset> updatedDateTimeOffsetProperty = updatedRecord.UpdateProperty( propertyName, propertyValue, isLocal );
+        ZfsProperty<DateTimeOffset> updatedDateTimeOffsetProperty = updatedRecord.UpdateProperty ( propertyName, propertyValue, isLocal );
 
         if ( newTestCaseProperty == originalDateTimeOffsetProperty )
         {
-            Assert.Multiple( ( ) =>
-            {
-                Assert.That( updatedDateTimeOffsetProperty, Is.EqualTo( originalDateTimeOffsetProperty ) );
-                Assert.That( updatedDateTimeOffsetProperty, Is.EqualTo( newTestCaseProperty ) );
-                Assert.That( updatedDateTimeOffsetProperty.Name, Is.EqualTo( propertyName ) );
-                Assert.That( updatedDateTimeOffsetProperty.Value, Is.EqualTo( propertyValue ) );
-                Assert.That( updatedDateTimeOffsetProperty.IsLocal, Is.EqualTo( isLocal ) );
+            Assert.Multiple (
+                             ( ) =>
+                             {
+                                 Assert.That ( updatedDateTimeOffsetProperty,         Is.EqualTo ( originalDateTimeOffsetProperty ).Using<ZfsProperty<DateTimeOffset>> ( DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedDateTimeOffsetProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<DateTimeOffset>> ( DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedDateTimeOffsetProperty.Name,    Is.EqualTo ( propertyName ) );
+                                 Assert.That ( updatedDateTimeOffsetProperty.Value,   Is.EqualTo ( propertyValue ) );
+                                 Assert.That ( updatedDateTimeOffsetProperty.IsLocal, Is.EqualTo ( isLocal ) );
 
-                Assert.That( updatedRecord, Is.EqualTo( originalRecord ) );
-            } );
+                                 Assert.That ( updatedRecord, Is.EqualTo ( originalRecord ) );
+                             } );
         }
         else
         {
-            Assert.Multiple( ( ) =>
-            {
-                Assert.That( updatedDateTimeOffsetProperty, Is.Not.EqualTo( originalDateTimeOffsetProperty ) );
-                Assert.That( updatedDateTimeOffsetProperty, Is.EqualTo( newTestCaseProperty ) );
-                Assert.That( updatedDateTimeOffsetProperty.Name, Is.EqualTo( propertyName ) );
-                Assert.That( updatedDateTimeOffsetProperty.Value, Is.EqualTo( propertyValue ) );
-                Assert.That( updatedDateTimeOffsetProperty.IsLocal, Is.EqualTo( isLocal ) );
+            Assert.Multiple (
+                             ( ) =>
+                             {
+                                 Assert.That ( updatedDateTimeOffsetProperty,         Is.Not.EqualTo ( originalDateTimeOffsetProperty ).Using<ZfsProperty<DateTimeOffset>> ( DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedDateTimeOffsetProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<DateTimeOffset>> ( DateTimeOffsetPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedDateTimeOffsetProperty.Name,    Is.EqualTo ( propertyName ) );
+                                 Assert.That ( updatedDateTimeOffsetProperty.Value,   Is.EqualTo ( propertyValue ) );
+                                 Assert.That ( updatedDateTimeOffsetProperty.IsLocal, Is.EqualTo ( isLocal ) );
 
-                Assert.That( updatedRecord, Is.Not.EqualTo( originalRecord ) );
-            } );
+                                 Assert.That ( updatedRecord, Is.Not.EqualTo ( originalRecord ) );
+                             } );
         }
 
         if ( !isLocal )
         {
-            Assert.Multiple( ( ) =>
-            {
-                Assert.That( updatedRecord[ propertyName ], Has.Property( "IsLocal" ).False );
-                Assert.That( updatedRecord[ propertyName ], Has.Property( "Source" ).EqualTo( $"inherited from {updatedParent.Name}" ) );
-            } );
+            Assert.Multiple (
+                             ( ) =>
+                             {
+                                 Assert.That ( updatedRecord [ propertyName ], Has.Property ( "IsLocal" ).False );
+                                 Assert.That ( updatedRecord [ propertyName ], Has.Property ( "Source" ).EqualTo ( $"inherited from {updatedParent.Name}" ) );
+                             } );
         }
     }
 
@@ -388,10 +392,10 @@ public class ZfsRecordTests
         {
             Assert.Multiple( ( ) =>
             {
-                Assert.That( updatedIntProperty, Is.EqualTo( originalIntProperty ) );
-                Assert.That( updatedIntProperty, Is.EqualTo( newTestCaseProperty ) );
-                Assert.That( updatedIntProperty.Name, Is.EqualTo( propertyName ) );
-                Assert.That( updatedIntProperty.Value, Is.EqualTo( propertyValue ) );
+                Assert.That( updatedIntProperty,         Is.EqualTo( originalIntProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
+                Assert.That( updatedIntProperty,         Is.EqualTo( newTestCaseProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
+                Assert.That( updatedIntProperty.Name,    Is.EqualTo( propertyName ) );
+                Assert.That( updatedIntProperty.Value,   Is.EqualTo( propertyValue ) );
                 Assert.That( updatedIntProperty.IsLocal, Is.EqualTo( isLocal ) );
 
                 Assert.That( updatedRecord, Is.EqualTo( originalRecord ) );
@@ -401,10 +405,10 @@ public class ZfsRecordTests
         {
             Assert.Multiple( ( ) =>
             {
-                Assert.That( updatedIntProperty, Is.Not.EqualTo( originalIntProperty ) );
-                Assert.That( updatedIntProperty, Is.EqualTo( newTestCaseProperty ) );
-                Assert.That( updatedIntProperty.Name, Is.EqualTo( propertyName ) );
-                Assert.That( updatedIntProperty.Value, Is.EqualTo( propertyValue ) );
+                Assert.That( updatedIntProperty,         Is.Not.EqualTo( originalIntProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
+                Assert.That( updatedIntProperty,         Is.EqualTo( newTestCaseProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
+                Assert.That( updatedIntProperty.Name,    Is.EqualTo( propertyName ) );
+                Assert.That( updatedIntProperty.Value,   Is.EqualTo( propertyValue ) );
                 Assert.That( updatedIntProperty.IsLocal, Is.EqualTo( isLocal ) );
 
                 Assert.That( updatedRecord, Is.Not.EqualTo( originalRecord ) );
@@ -440,12 +444,12 @@ public class ZfsRecordTests
         if ( newTestCaseProperty == originalStringProperty )
         {
             Assert.Multiple( ( ) =>
-            {
-                Assert.That( updatedStringProperty, Is.EqualTo( originalStringProperty ) );
-                Assert.That( updatedStringProperty, Is.EqualTo( newTestCaseProperty ) );
-                Assert.That( updatedStringProperty.Name, Is.EqualTo( propertyName ) );
-                Assert.That( updatedStringProperty.Value, Is.EqualTo( propertyValue ) );
-                Assert.That( updatedStringProperty.IsLocal, Is.EqualTo( isLocal ) );
+                             {
+                                 Assert.That ( updatedStringProperty, Is.EqualTo ( originalStringProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
+                Assert.That( updatedStringProperty,                   Is.EqualTo( newTestCaseProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
+                Assert.That( updatedStringProperty.Name,              Is.EqualTo( propertyName ) );
+                Assert.That( updatedStringProperty.Value,             Is.EqualTo( propertyValue ) );
+                Assert.That( updatedStringProperty.IsLocal,           Is.EqualTo( isLocal ) );
 
                 Assert.That( updatedRecord, Is.EqualTo( originalRecord ) );
             } );
@@ -454,10 +458,10 @@ public class ZfsRecordTests
         {
             Assert.Multiple( ( ) =>
             {
-                Assert.That( updatedStringProperty, Is.Not.EqualTo( originalStringProperty ) );
-                Assert.That( updatedStringProperty, Is.EqualTo( newTestCaseProperty ) );
-                Assert.That( updatedStringProperty.Name, Is.EqualTo( propertyName ) );
-                Assert.That( updatedStringProperty.Value, Is.EqualTo( propertyValue ) );
+                Assert.That( updatedStringProperty,         Is.Not.EqualTo( originalStringProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
+                Assert.That( updatedStringProperty,         Is.EqualTo( newTestCaseProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
+                Assert.That( updatedStringProperty.Name,    Is.EqualTo( propertyName ) );
+                Assert.That( updatedStringProperty.Value,   Is.EqualTo( propertyValue ) );
                 Assert.That( updatedStringProperty.IsLocal, Is.EqualTo( isLocal ) );
 
                 Assert.That( updatedRecord, Is.Not.EqualTo( originalRecord ) );
@@ -474,8 +478,9 @@ public class ZfsRecordTests
         }
     }
 
-    private static ZfsProperty<bool> GetBoolPropertyByValueFromDataset( ZfsRecord dataset, string propertyName )
-    {
-        return (ZfsProperty<bool>)dataset[ propertyName ];
-    }
+    private static ZfsProperty<bool> GetBoolPropertyByValueFromDataset ( ZfsRecord dataset, string propertyName ) => (ZfsProperty<bool>)dataset [ propertyName ];
+    private static bool DateTimeOffsetPropertyComparer_Force_op_Equality ( ZfsProperty<DateTimeOffset> left, ZfsProperty<DateTimeOffset> right ) => left == right;
+    private static bool BoolPropertyComparer_Force_op_Equality ( ZfsProperty<bool>                     left, ZfsProperty<bool>           right ) => left == right;
+    private static bool IntPropertyComparer_Force_op_Equality ( ZfsProperty<int>                       left, ZfsProperty<int>            right ) => left == right;
+    private static bool StringPropertyComparer_Force_op_Equality ( ZfsProperty<string>                 left, ZfsProperty<string>         right ) => left == right;
 }

--- a/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsRecordTests/ZfsRecordTests.cs
+++ b/Tests/SnapsInAZfs.Interop.Tests/Zfs/ZfsTypes/ZfsRecordTests/ZfsRecordTests.cs
@@ -1,12 +1,16 @@
-// LICENSE:
+#region MIT LICENSE
+
+// Copyright 2025 Brandon Thetford
 // 
-// Copyright 2023 Brandon Thetford
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 // 
 // The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 // 
-// THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// 
+// See https://opensource.org/license/MIT/
+
+#endregion
 
 using System.Globalization;
 using SnapsInAZfs.Interop.Tests.Zfs.ZfsTypes.SnapshotTests;
@@ -16,119 +20,88 @@ using SnapsInAZfs.Settings.Settings;
 namespace SnapsInAZfs.Interop.Tests.Zfs.ZfsTypes.ZfsRecordTests;
 
 [TestFixture]
-[Category( "General" )]
+[Category ( "General" )]
 [Parallelizable]
-[TestOf( typeof( ZfsRecord ) )]
+[TestOf ( typeof (ZfsRecord) )]
 public class ZfsRecordTests
 {
-    private static readonly IReadOnlyList<string> UpdateProperty_DateTimeOffset_Values = new[] { "2022-01-01T00:00:00.0000000", "2023-01-01T00:00:00.0000000", "2023-07-01T00:00:00.0000000", "2023-07-03T00:00:00.0000000", "2023-07-03T00:00:00.0000000", "2023-07-03T00:00:00.0000000", "2023-07-03T01:00:00.0000000", "2023-07-03T01:15:00.0000000", "2023-12-31T23:59:59.9999999", "2024-01-01T00:00:00.0000000" };
+    private static readonly IReadOnlyList<string> UpdateProperty_DateTimeOffset_Values = new [] { "2022-01-01T00:00:00.0000000", "2023-01-01T00:00:00.0000000", "2023-07-01T00:00:00.0000000", "2023-07-03T00:00:00.0000000", "2023-07-03T00:00:00.0000000", "2023-07-03T00:00:00.0000000", "2023-07-03T01:00:00.0000000", "2023-07-03T01:15:00.0000000", "2023-12-31T23:59:59.9999999", "2024-01-01T00:00:00.0000000" };
 
     [Test]
-    public void BoolPropertyChangedEventHandler_SubscribersReceiveEventAndUpdateProperties_ChildPropertyIsInherited( )
+    public void BoolPropertyChangedEventHandler_SubscribersReceiveEventAndUpdateProperties_ChildPropertyIsInherited ( )
     {
-        ZfsRecord originalParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem( );
-        ZfsRecord originalChild = originalParent.CreateChildDataset( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsRecord originalParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( );
+        ZfsRecord originalChild  = originalParent.CreateChildDataset ( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
 
-        ZfsRecord updatedParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem( );
-        ZfsRecord updatedChild = updatedParent.CreateChildDataset( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsRecord updatedParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( );
+        ZfsRecord updatedChild  = updatedParent.CreateChildDataset ( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
 
-        Assume.That( updatedChild.Equals( originalChild ), Is.True );
-        Assume.That( updatedChild.Enabled.IsInherited, Is.True );
-        Assume.That( updatedChild.TakeSnapshots.IsInherited, Is.True );
-        Assume.That( updatedChild.PruneSnapshots.IsInherited, Is.True );
+        Assume.That ( updatedChild.Equals ( originalChild ),   Is.True );
+        Assume.That ( updatedChild.Enabled.IsInherited,        Is.True );
+        Assume.That ( updatedChild.TakeSnapshots.IsInherited,  Is.True );
+        Assume.That ( updatedChild.PruneSnapshots.IsInherited, Is.True );
 
 #pragma warning disable NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
-        ZfsProperty<bool> originalEnabledProperty = originalChild.Enabled;
+        ZfsProperty<bool> originalEnabledProperty                  = originalChild.Enabled;
         ZfsProperty<bool> updatedChildEnabledProperty_BeforeUpdate = updatedChild.Enabled;
-        ZfsProperty<bool> updatedChildEnabledProperty_AfterUpdate = updatedParent.UpdateProperty( ZfsPropertyNames.EnabledPropertyName, false );
-        Assert.That( updatedChildEnabledProperty_AfterUpdate, Is.Not.EqualTo( updatedChildEnabledProperty_BeforeUpdate ) );
+        ZfsProperty<bool> updatedChildEnabledProperty_AfterUpdate  = updatedParent.UpdateProperty ( ZfsPropertyNames.EnabledPropertyName, false );
+        Assert.That ( updatedChildEnabledProperty_AfterUpdate, Is.Not.EqualTo ( updatedChildEnabledProperty_BeforeUpdate ) );
         updatedChildEnabledProperty_BeforeUpdate = updatedChildEnabledProperty_AfterUpdate;
-        Assert.Multiple( ( ) =>
-        {
-            Assert.That( updatedChild.Equals( originalChild ), Is.False );
-            Assert.That( updatedChild.Enabled.Value, Is.EqualTo( updatedParent.Enabled.Value ) );
-            Assert.That( updatedChildEnabledProperty_BeforeUpdate, Is.Not.EqualTo( originalEnabledProperty ) );
-        } );
 
-        ZfsProperty<bool> originalTakeSnapshotsProperty = originalChild.TakeSnapshots;
+        Assert.Multiple (
+                         ( ) =>
+                         {
+                             Assert.That ( updatedChild.Equals ( originalChild ),    Is.False );
+                             Assert.That ( updatedChild.Enabled.Value,               Is.EqualTo ( updatedParent.Enabled.Value ) );
+                             Assert.That ( updatedChildEnabledProperty_BeforeUpdate, Is.Not.EqualTo ( originalEnabledProperty ) );
+                         } );
+
+        ZfsProperty<bool> originalTakeSnapshotsProperty                  = originalChild.TakeSnapshots;
         ZfsProperty<bool> updatedChildTakeSnapshotsProperty_BeforeUpdate = updatedChild.TakeSnapshots;
-        ZfsProperty<bool> updatedChildTakeSnapshotsProperty_AfterUpdate = updatedParent.UpdateProperty( ZfsPropertyNames.TakeSnapshotsPropertyName, false );
-        Assert.That( updatedChildTakeSnapshotsProperty_AfterUpdate, Is.Not.EqualTo( updatedChildTakeSnapshotsProperty_BeforeUpdate ) );
+        ZfsProperty<bool> updatedChildTakeSnapshotsProperty_AfterUpdate  = updatedParent.UpdateProperty ( ZfsPropertyNames.TakeSnapshotsPropertyName, false );
+        Assert.That ( updatedChildTakeSnapshotsProperty_AfterUpdate, Is.Not.EqualTo ( updatedChildTakeSnapshotsProperty_BeforeUpdate ) );
         updatedChildTakeSnapshotsProperty_BeforeUpdate = updatedChildTakeSnapshotsProperty_AfterUpdate;
-        Assert.Multiple( ( ) =>
-        {
-            Assert.That( updatedChild.Equals( originalChild ), Is.False );
-            Assert.That( updatedChild.TakeSnapshots.Value, Is.EqualTo( updatedParent.TakeSnapshots.Value ) );
-            Assert.That( updatedChildTakeSnapshotsProperty_BeforeUpdate, Is.Not.EqualTo( originalTakeSnapshotsProperty ) );
-        } );
 
-        ZfsProperty<bool> originalPruneSnapshotsProperty = originalChild.PruneSnapshots;
+        Assert.Multiple (
+                         ( ) =>
+                         {
+                             Assert.That ( updatedChild.Equals ( originalChild ),          Is.False );
+                             Assert.That ( updatedChild.TakeSnapshots.Value,               Is.EqualTo ( updatedParent.TakeSnapshots.Value ) );
+                             Assert.That ( updatedChildTakeSnapshotsProperty_BeforeUpdate, Is.Not.EqualTo ( originalTakeSnapshotsProperty ) );
+                         } );
+
+        ZfsProperty<bool> originalPruneSnapshotsProperty                  = originalChild.PruneSnapshots;
         ZfsProperty<bool> updatedChildPruneSnapshotsProperty_BeforeUpdate = updatedChild.PruneSnapshots;
-        ZfsProperty<bool> updatedChildPruneSnapshotsProperty_AfterUpdate = updatedParent.UpdateProperty( ZfsPropertyNames.PruneSnapshotsPropertyName, false );
-        Assert.That( updatedChildPruneSnapshotsProperty_AfterUpdate, Is.Not.EqualTo( updatedChildPruneSnapshotsProperty_BeforeUpdate ) );
+        ZfsProperty<bool> updatedChildPruneSnapshotsProperty_AfterUpdate  = updatedParent.UpdateProperty ( ZfsPropertyNames.PruneSnapshotsPropertyName, false );
+        Assert.That ( updatedChildPruneSnapshotsProperty_AfterUpdate, Is.Not.EqualTo ( updatedChildPruneSnapshotsProperty_BeforeUpdate ) );
         updatedChildPruneSnapshotsProperty_BeforeUpdate = updatedChildPruneSnapshotsProperty_AfterUpdate;
-        Assert.Multiple( ( ) =>
-        {
-            Assert.That( updatedChild.Equals( originalChild ), Is.False );
-            Assert.That( updatedChild.PruneSnapshots.Value, Is.EqualTo( updatedParent.PruneSnapshots.Value ) );
-            Assert.That( updatedChildPruneSnapshotsProperty_BeforeUpdate, Is.Not.EqualTo( originalPruneSnapshotsProperty ) );
-        } );
+
+        Assert.Multiple (
+                         ( ) =>
+                         {
+                             Assert.That ( updatedChild.Equals ( originalChild ),           Is.False );
+                             Assert.That ( updatedChild.PruneSnapshots.Value,               Is.EqualTo ( updatedParent.PruneSnapshots.Value ) );
+                             Assert.That ( updatedChildPruneSnapshotsProperty_BeforeUpdate, Is.Not.EqualTo ( originalPruneSnapshotsProperty ) );
+                         } );
 #pragma warning restore NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
     }
 
     [Test]
-    [Category( "General" )]
-    [Category( "TypeChecks" )]
-    [TestCase( "" )]
-    [TestCase( " " )]
-    [TestCase( "  " )]
-    [TestCase( "\t" )]
-    [TestCase( "\n" )]
-    [TestCase( "\r" )]
-    [TestCase( null, Description = "Test what happens if an external caller does not respect nullability context and gives us a null value anyway")]
-    public void CreateChildDataset_ThrowsOnSourceSystemNullEmptyOrWhitespace( string? sourceSystem )
+    [TestCase ( ZfsPropertyNames.EnabledPropertyName )]
+    public void BoolPropertyChangedEventHandler_SubscribersReceiveEventAndUpdateProperties_ChildPropertyIsLocal ( string propertyName )
     {
-        ZfsRecord gen1Ds = ZfsRecordTestHelpers.GetNewTestRootFileSystem( "gen1" );
-#pragma warning disable CS8604 // Possible null reference argument - Intentional
-        Assert.That( ( ) => { gen1Ds.CreateChildDataset( "badChild", ZfsPropertyValueConstants.FileSystem, sourceSystem ); }, Throws.ArgumentNullException );
-#pragma warning restore CS8604 // Possible null reference argument - Intentional
-    }
-
-    [Test]
-    [Category( "General" )]
-    [Category( "TypeChecks" )]
-    [TestCase( "" )]
-    [TestCase( " " )]
-    [TestCase( "  " )]
-    [TestCase( "\t" )]
-    [TestCase( "\n" )]
-    [TestCase( "\r" )]
-    [TestCase( null, Description = "Test what happens if an external caller does not respect nullability context and gives us a null value anyway")]
-    public void CreateSnapshot_ThrowsOnSourceSystemNullEmptyOrWhitespace( string? sourceSystem )
-    {
-        ZfsRecord gen1Ds = ZfsRecordTestHelpers.GetNewTestRootFileSystem( "gen1" );
-        FormattingSettings formattingSettings = FormattingSettings.GetDefault( );
-#pragma warning disable CS8601 // Possible null reference assignment - Intentional
-        Assert.That( ( ) => { gen1Ds.CreateSnapshot( SnapshotPeriod.Frequent, DateTimeOffset.Now, in formattingSettings, gen1Ds.SourceSystem with { Value = sourceSystem } ); }, Throws.ArgumentException );
-#pragma warning restore CS8601 // Possible null reference assignment - Intentional
-    }
-
-    [Test]
-    [TestCase( ZfsPropertyNames.EnabledPropertyName )]
-    public void BoolPropertyChangedEventHandler_SubscribersReceiveEventAndUpdateProperties_ChildPropertyIsLocal( string propertyName )
-    {
-        ZfsRecord gen1Ds = ZfsRecordTestHelpers.GetNewTestRootFileSystem( "gen1" );
-        ZfsRecord gen2Ds = gen1Ds.CreateChildDataset( "gen1/gen2", ZfsPropertyValueConstants.FileSystem, "testSystem" );
-        ZfsRecord gen3Ds = gen2Ds.CreateChildDataset( "gen1/gen2/gen3", ZfsPropertyValueConstants.FileSystem, "testSystem" );
-        ZfsRecord gen4Ds = gen3Ds.CreateChildDataset( "gen1/gen2/gen3/gen4", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsRecord gen1Ds = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( "gen1" );
+        ZfsRecord gen2Ds = gen1Ds.CreateChildDataset ( "gen1/gen2", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsRecord gen3Ds = gen2Ds.CreateChildDataset ( "gen1/gen2/gen3", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsRecord gen4Ds = gen3Ds.CreateChildDataset ( "gen1/gen2/gen3/gen4", ZfsPropertyValueConstants.FileSystem, "testSystem" );
 
         // Now change the property to local on gen 3 by setting it explicitly
-        gen3Ds.UpdateProperty( propertyName, true );
+        gen3Ds.UpdateProperty ( propertyName, true );
 
-        ZfsProperty<bool> gen1Property = GetBoolPropertyByValueFromDataset( gen1Ds, propertyName );
-        ZfsProperty<bool> gen2Property = GetBoolPropertyByValueFromDataset( gen2Ds, propertyName );
-        ZfsProperty<bool> gen3Property = GetBoolPropertyByValueFromDataset( gen3Ds, propertyName );
-        ZfsProperty<bool> gen4Property = GetBoolPropertyByValueFromDataset( gen4Ds, propertyName );
+        ZfsProperty<bool> gen1Property = GetBoolPropertyByValueFromDataset ( gen1Ds, propertyName );
+        ZfsProperty<bool> gen2Property = GetBoolPropertyByValueFromDataset ( gen2Ds, propertyName );
+        ZfsProperty<bool> gen3Property = GetBoolPropertyByValueFromDataset ( gen3Ds, propertyName );
+        ZfsProperty<bool> gen4Property = GetBoolPropertyByValueFromDataset ( gen4Ds, propertyName );
 
         // Subscribe to the property change event handlers
         bool gen1EventFired = false;
@@ -145,150 +118,198 @@ public class ZfsRecordTests
         // Gen 2 and 4 properties are inherited
         // Gen 2 inherits from gen 1
         // Gen 4 inherits from gen 3
-        Assume.That( gen1Property.IsLocal, Is.True );
-        Assume.That( gen2Property.IsLocal, Is.False );
-        Assume.That( gen2Property.Source, Does.EndWith( gen1Ds.Name ) );
-        Assume.That( gen3Property.IsLocal, Is.True );
-        Assume.That( gen4Property.IsLocal, Is.False );
-        Assume.That( gen4Property.Source, Does.EndWith( gen3Ds.Name ) );
+        Assume.That ( gen1Property.IsLocal, Is.True );
+        Assume.That ( gen2Property.IsLocal, Is.False );
+        Assume.That ( gen2Property.Source,  Does.EndWith ( gen1Ds.Name ) );
+        Assume.That ( gen3Property.IsLocal, Is.True );
+        Assume.That ( gen4Property.IsLocal, Is.False );
+        Assume.That ( gen4Property.Source,  Does.EndWith ( gen3Ds.Name ) );
 
         // Set the property to the opposite of what it was on gen 1 and grab all 4 generations of that property
-        ZfsProperty<bool> gen1PropertyAfterChange = gen1Ds.UpdateProperty( propertyName, !gen1Property.Value );
-        ZfsProperty<bool> gen2PropertyAfterChange = GetBoolPropertyByValueFromDataset( gen2Ds, propertyName );
-        ZfsProperty<bool> gen3PropertyAfterChange = GetBoolPropertyByValueFromDataset( gen3Ds, propertyName );
-        ZfsProperty<bool> gen4PropertyAfterChange = GetBoolPropertyByValueFromDataset( gen4Ds, propertyName );
+        ZfsProperty<bool> gen1PropertyAfterChange = gen1Ds.UpdateProperty ( propertyName, !gen1Property.Value );
+        ZfsProperty<bool> gen2PropertyAfterChange = GetBoolPropertyByValueFromDataset ( gen2Ds, propertyName );
+        ZfsProperty<bool> gen3PropertyAfterChange = GetBoolPropertyByValueFromDataset ( gen3Ds, propertyName );
+        ZfsProperty<bool> gen4PropertyAfterChange = GetBoolPropertyByValueFromDataset ( gen4Ds, propertyName );
 
         // Only gen 1 and 2 event handlers should have fired
-        Assert.Multiple( ( ) =>
-        {
-            Assert.That( gen1EventFired, Is.True, "Generation 1 event did not fire." );
-            Assert.That( gen2EventFired, Is.True, "Generation 2 event did not fire." );
-            Assert.That( gen3EventFired, Is.False, "Generation 3 event fired." );
-            Assert.That( gen4EventFired, Is.False, "Generation 4 event fired." );
-        } );
+        Assert.Multiple (
+                         ( ) =>
+                         {
+                             Assert.That ( gen1EventFired, Is.True,  "Generation 1 event did not fire." );
+                             Assert.That ( gen2EventFired, Is.True,  "Generation 2 event did not fire." );
+                             Assert.That ( gen3EventFired, Is.False, "Generation 3 event fired." );
+                             Assert.That ( gen4EventFired, Is.False, "Generation 4 event fired." );
+                         } );
 
         // Values of gen 1 and 2 properties should have changed
-        Assert.Multiple( ( ) =>
-        {
-            Assert.That( gen1PropertyAfterChange.Value, Is.Not.EqualTo( gen1Property.Value ) );
-            Assert.That( gen2PropertyAfterChange.Value, Is.Not.EqualTo( gen2Property.Value ) );
-            Assert.That( gen3PropertyAfterChange.Value, Is.EqualTo( gen3Property.Value ) );
-            Assert.That( gen4PropertyAfterChange.Value, Is.EqualTo( gen4Property.Value ) );
-        } );
+        Assert.Multiple (
+                         ( ) =>
+                         {
+                             Assert.That ( gen1PropertyAfterChange.Value, Is.Not.EqualTo ( gen1Property.Value ) );
+                             Assert.That ( gen2PropertyAfterChange.Value, Is.Not.EqualTo ( gen2Property.Value ) );
+                             Assert.That ( gen3PropertyAfterChange.Value, Is.EqualTo ( gen3Property.Value ) );
+                             Assert.That ( gen4PropertyAfterChange.Value, Is.EqualTo ( gen4Property.Value ) );
+                         } );
 
         // Sources should not have changed
-        Assert.Multiple( ( ) =>
-        {
-            Assert.That( gen1PropertyAfterChange.Source, Is.EqualTo( gen1Property.Source ) );
-            Assert.That( gen2PropertyAfterChange.Source, Is.EqualTo( gen2Property.Source ) );
-            Assert.That( gen3PropertyAfterChange.Source, Is.EqualTo( gen3Property.Source ) );
-            Assert.That( gen4PropertyAfterChange.Source, Is.EqualTo( gen4Property.Source ) );
-        } );
+        Assert.Multiple (
+                         ( ) =>
+                         {
+                             Assert.That ( gen1PropertyAfterChange.Source, Is.EqualTo ( gen1Property.Source ) );
+                             Assert.That ( gen2PropertyAfterChange.Source, Is.EqualTo ( gen2Property.Source ) );
+                             Assert.That ( gen3PropertyAfterChange.Source, Is.EqualTo ( gen3Property.Source ) );
+                             Assert.That ( gen4PropertyAfterChange.Source, Is.EqualTo ( gen4Property.Source ) );
+                         } );
     }
 
     [Test]
-    public void DeepCopyClone_NewObjectEqual( )
+    [Category ( "General" )]
+    [Category ( "TypeChecks" )]
+    [TestCase ( "" )]
+    [TestCase ( " " )]
+    [TestCase ( "  " )]
+    [TestCase ( "\t" )]
+    [TestCase ( "\n" )]
+    [TestCase ( "\r" )]
+    [TestCase ( null, Description = "Test what happens if an external caller does not respect nullability context and gives us a null value anyway" )]
+    public void CreateChildDataset_ThrowsOnSourceSystemNullEmptyOrWhitespace ( string? sourceSystem )
     {
-        ZfsRecord sourceRecord = ZfsRecordTestHelpers.GetNewTestRootFileSystem( );
-        sourceRecord.AddSnapshot( SnapshotTestHelpers.GetStandardTestSnapshotForParent( SnapshotPeriod.Daily, DateTimeOffset.Now, sourceRecord ) );
+        ZfsRecord gen1Ds = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( "gen1" );
+#pragma warning disable CS8604 // Possible null reference argument - Intentional
+        Assert.That ( ( ) => { gen1Ds.CreateChildDataset ( "badChild", ZfsPropertyValueConstants.FileSystem, sourceSystem ); }, Throws.ArgumentNullException );
+#pragma warning restore CS8604 // Possible null reference argument - Intentional
+    }
 
-        ZfsRecord clonedRecord = sourceRecord.DeepCopyClone( );
+    [Test]
+    [Category ( "General" )]
+    [Category ( "TypeChecks" )]
+    [TestCase ( "" )]
+    [TestCase ( " " )]
+    [TestCase ( "  " )]
+    [TestCase ( "\t" )]
+    [TestCase ( "\n" )]
+    [TestCase ( "\r" )]
+    [TestCase ( null, Description = "Test what happens if an external caller does not respect nullability context and gives us a null value anyway" )]
+    public void CreateSnapshot_ThrowsOnSourceSystemNullEmptyOrWhitespace ( string? sourceSystem )
+    {
+        ZfsRecord          gen1Ds             = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( "gen1" );
+        FormattingSettings formattingSettings = FormattingSettings.GetDefault ( );
+#pragma warning disable CS8601 // Possible null reference assignment - Intentional
+        Assert.That ( ( ) => { gen1Ds.CreateSnapshot ( SnapshotPeriod.Frequent, DateTimeOffset.Now, in formattingSettings, gen1Ds.SourceSystem with { Value = sourceSystem } ); }, Throws.ArgumentException );
+#pragma warning restore CS8601 // Possible null reference assignment - Intentional
+    }
+
+    [Test]
+    public void DeepCopyClone_NewObjectEqual ( )
+    {
+        ZfsRecord sourceRecord = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( );
+        sourceRecord.AddSnapshot ( SnapshotTestHelpers.GetStandardTestSnapshotForParent ( SnapshotPeriod.Daily, DateTimeOffset.Now, sourceRecord ) );
+
+        ZfsRecord clonedRecord = sourceRecord.DeepCopyClone ( );
 
 #pragma warning disable NUnit2010
-        Assert.That( clonedRecord.Equals( sourceRecord ), Is.True );
+        Assert.That ( clonedRecord.Equals ( sourceRecord ), Is.True );
 #pragma warning restore NUnit2010
     }
 
     [Test]
-    public void DeepCopyClone_NewObjectNotReferenceToOriginal( )
+    public void DeepCopyClone_NewObjectNotReferenceToOriginal ( )
     {
-        ZfsRecord sourceRecord = ZfsRecordTestHelpers.GetNewTestRootFileSystem( );
-        sourceRecord.AddSnapshot( SnapshotTestHelpers.GetStandardTestSnapshotForParent( SnapshotPeriod.Daily, DateTimeOffset.Now, sourceRecord ) );
+        ZfsRecord sourceRecord = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( );
+        sourceRecord.AddSnapshot ( SnapshotTestHelpers.GetStandardTestSnapshotForParent ( SnapshotPeriod.Daily, DateTimeOffset.Now, sourceRecord ) );
 
-        ZfsRecord clonedRecord = sourceRecord.DeepCopyClone( );
+        ZfsRecord clonedRecord = sourceRecord.DeepCopyClone ( );
 
-        Assert.That( ReferenceEquals( clonedRecord, sourceRecord ), Is.False );
+        Assert.That ( ReferenceEquals ( clonedRecord, sourceRecord ), Is.False );
     }
 
     [Test]
-    [TestCase( "sameName", ZfsPropertyValueConstants.FileSystem, "sameName", ZfsPropertyValueConstants.FileSystem, ExpectedResult = true )]
-    [TestCase( "differentNameA", ZfsPropertyValueConstants.FileSystem, "differentNameB", ZfsPropertyValueConstants.FileSystem, ExpectedResult = false )]
-    [TestCase( "sameName", ZfsPropertyValueConstants.FileSystem, "sameName", ZfsPropertyValueConstants.Volume, ExpectedResult = false )]
-    [TestCase( "differentNameA", ZfsPropertyValueConstants.FileSystem, "differentNameB", ZfsPropertyValueConstants.Volume, ExpectedResult = false )]
-    public bool EqualityIsByRecordValue( string datasetAName, string datasetAKind, string datasetBName, string datasetBKind )
+    [TestCase ( "sameName",       ZfsPropertyValueConstants.FileSystem, "sameName",       ZfsPropertyValueConstants.FileSystem, ExpectedResult = true )]
+    [TestCase ( "differentNameA", ZfsPropertyValueConstants.FileSystem, "differentNameB", ZfsPropertyValueConstants.FileSystem, ExpectedResult = false )]
+    [TestCase ( "sameName",       ZfsPropertyValueConstants.FileSystem, "sameName",       ZfsPropertyValueConstants.Volume,     ExpectedResult = false )]
+    [TestCase ( "differentNameA", ZfsPropertyValueConstants.FileSystem, "differentNameB", ZfsPropertyValueConstants.Volume,     ExpectedResult = false )]
+    public bool EqualityIsByRecordValue ( string datasetAName, string datasetAKind, string datasetBName, string datasetBKind )
     {
         // This test should be enhanced to check more cases of inequality
         // Providing a test case provider method would help with that
-        ZfsRecord datasetA = new( datasetAName, datasetAKind, "testSystem" );
-        ZfsRecord datasetB = new( datasetBName, datasetBKind, "testSystem" );
+        ZfsRecord datasetA = new ( datasetAName, datasetAKind, "testSystem" );
+        ZfsRecord datasetB = new ( datasetBName, datasetBKind, "testSystem" );
+
         return datasetA == datasetB;
     }
 
     [Test]
-    public void IntPropertyChangedEventHandler_SubscribersReceiveEventAndUpdateProperties_ChildInherits( )
+    public void IntPropertyChangedEventHandler_SubscribersReceiveEventAndUpdateProperties_ChildInherits ( )
     {
-        ZfsRecord originalParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem( );
-        ZfsRecord originalRecord = originalParent.CreateChildDataset( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
-        ZfsRecord updatedParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem( );
-        ZfsRecord updatedRecord = updatedParent.CreateChildDataset( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsRecord originalParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( );
+        ZfsRecord originalRecord = originalParent.CreateChildDataset ( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsRecord updatedParent  = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( );
+        ZfsRecord updatedRecord  = updatedParent.CreateChildDataset ( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
 
 #pragma warning disable NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
-        Assume.That( updatedRecord.Equals( originalRecord ), Is.True );
+        Assume.That ( updatedRecord.Equals ( originalRecord ), Is.True );
         ZfsProperty<bool> originalEnabledProperty = originalRecord.Enabled;
-        ZfsProperty<bool> updatedEnabledProperty = updatedParent.UpdateProperty( ZfsPropertyNames.EnabledPropertyName, false );
-        Assert.Multiple( ( ) =>
-        {
-            Assert.That( updatedRecord.Equals( originalRecord ), Is.False );
-            Assert.That( updatedRecord.Enabled.Value, Is.EqualTo( updatedParent.Enabled.Value ) );
-            Assert.That( updatedEnabledProperty, Is.Not.EqualTo( originalEnabledProperty ) );
-        } );
+        ZfsProperty<bool> updatedEnabledProperty  = updatedParent.UpdateProperty ( ZfsPropertyNames.EnabledPropertyName, false );
+
+        Assert.Multiple (
+                         ( ) =>
+                         {
+                             Assert.That ( updatedRecord.Equals ( originalRecord ), Is.False );
+                             Assert.That ( updatedRecord.Enabled.Value,             Is.EqualTo ( updatedParent.Enabled.Value ) );
+                             Assert.That ( updatedEnabledProperty,                  Is.Not.EqualTo ( originalEnabledProperty ) );
+                         } );
         ZfsProperty<bool> originalTakeSnapshotsProperty = originalRecord.TakeSnapshots;
-        ZfsProperty<bool> updatedTakeSnapshotsProperty = updatedParent.UpdateProperty( ZfsPropertyNames.TakeSnapshotsPropertyName, false );
-        Assert.Multiple( ( ) =>
-        {
-            Assert.That( updatedRecord.Equals( originalRecord ), Is.False );
-            Assert.That( updatedRecord.Enabled.Value, Is.EqualTo( updatedParent.Enabled.Value ) );
-            Assert.That( updatedTakeSnapshotsProperty, Is.Not.EqualTo( originalTakeSnapshotsProperty ) );
-        } );
+        ZfsProperty<bool> updatedTakeSnapshotsProperty  = updatedParent.UpdateProperty ( ZfsPropertyNames.TakeSnapshotsPropertyName, false );
+
+        Assert.Multiple (
+                         ( ) =>
+                         {
+                             Assert.That ( updatedRecord.Equals ( originalRecord ), Is.False );
+                             Assert.That ( updatedRecord.Enabled.Value,             Is.EqualTo ( updatedParent.Enabled.Value ) );
+                             Assert.That ( updatedTakeSnapshotsProperty,            Is.Not.EqualTo ( originalTakeSnapshotsProperty ) );
+                         } );
         ZfsProperty<bool> originalPruneSnapshotsProperty = originalRecord.TakeSnapshots;
-        ZfsProperty<bool> updatedPruneSnapshotsProperty = updatedParent.UpdateProperty( ZfsPropertyNames.PruneSnapshotsPropertyName, false );
-        Assert.Multiple( ( ) =>
-        {
-            Assert.That( updatedRecord.Equals( originalRecord ), Is.False );
+        ZfsProperty<bool> updatedPruneSnapshotsProperty  = updatedParent.UpdateProperty ( ZfsPropertyNames.PruneSnapshotsPropertyName, false );
+
+        Assert.Multiple (
+                         ( ) =>
+                         {
+                             Assert.That ( updatedRecord.Equals ( originalRecord ), Is.False );
 #pragma warning restore NUnit2010 // Use EqualConstraint for better assertion messages in case of failure
-            Assert.That( updatedRecord.Enabled.Value, Is.EqualTo( updatedParent.Enabled.Value ) );
-            Assert.That( updatedPruneSnapshotsProperty, Is.Not.EqualTo( originalPruneSnapshotsProperty ) );
-        } );
+                             Assert.That ( updatedRecord.Enabled.Value,   Is.EqualTo ( updatedParent.Enabled.Value ) );
+                             Assert.That ( updatedPruneSnapshotsProperty, Is.Not.EqualTo ( originalPruneSnapshotsProperty ) );
+                         } );
     }
 
     [Test]
     [Combinatorial]
-    public void UpdateProperty_Bool( [Values( ZfsPropertyNames.EnabledPropertyName, ZfsPropertyNames.TakeSnapshotsPropertyName, ZfsPropertyNames.PruneSnapshotsPropertyName )] string propertyName, [Values] bool propertyValue, [Values] bool isLocal )
+    public void UpdateProperty_Bool ( [Values ( ZfsPropertyNames.EnabledPropertyName, ZfsPropertyNames.TakeSnapshotsPropertyName, ZfsPropertyNames.PruneSnapshotsPropertyName )] string propertyName, [Values] bool propertyValue, [Values] bool isLocal )
     {
-        ZfsRecord originalParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem( );
-        ZfsRecord originalRecord = originalParent.CreateChildDataset( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
-        ZfsRecord updatedParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem( );
-        ZfsRecord updatedRecord = updatedParent.CreateChildDataset( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
-        ZfsProperty<bool> newTestCaseProperty = new( originalRecord, propertyName, propertyValue, isLocal );
-        ZfsProperty<bool> originalBoolProperty = (ZfsProperty<bool>)originalRecord[ propertyName ];
+        ZfsRecord         originalParent       = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( );
+        ZfsRecord         originalRecord       = originalParent.CreateChildDataset ( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsRecord         updatedParent        = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( );
+        ZfsRecord         updatedRecord        = updatedParent.CreateChildDataset ( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsProperty<bool> newTestCaseProperty  = new ( originalRecord, propertyName, propertyValue, isLocal );
+        ZfsProperty<bool> originalBoolProperty = (ZfsProperty<bool>)originalRecord [ propertyName ];
 
-        Assume.That( updatedRecord, Is.EqualTo( originalRecord ), "Both records must be identical for this test to be valid" );
-        Assume.That( updatedRecord, Is.Not.SameAs( originalRecord ) );
+        Assume.That ( updatedRecord, Is.EqualTo ( originalRecord ), "Both records must be identical for this test to be valid" );
+        Assume.That ( updatedRecord, Is.Not.SameAs ( originalRecord ) );
 
-        ZfsProperty<bool> updatedBoolProperty = updatedRecord.UpdateProperty( propertyName, propertyValue, isLocal );
+        ZfsProperty<bool> updatedBoolProperty = updatedRecord.UpdateProperty ( propertyName, propertyValue, isLocal );
 
         if ( newTestCaseProperty == originalBoolProperty )
         {
-            Assert.Multiple( ( ) =>
+            Assert.Multiple (
+                             ( ) =>
                              {
-                                 Assert.That ( updatedBoolProperty, Is.EqualTo ( originalBoolProperty ).Using<ZfsProperty<bool>> ( BoolPropertyComparer_Force_op_Equality ) );
-                Assert.That ( updatedBoolProperty,                  Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<bool>> ( BoolPropertyComparer_Force_op_Equality ) );
-                Assert.That( updatedBoolProperty.Name,              Is.EqualTo( propertyName ) );
-                Assert.That( updatedBoolProperty.Value,             Is.EqualTo( propertyValue ) );
-                Assert.That( updatedBoolProperty.IsLocal,           Is.EqualTo( isLocal ) );
+                                 Assert.That ( updatedBoolProperty,         Is.EqualTo ( originalBoolProperty ).Using<ZfsProperty<bool>> ( BoolPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedBoolProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<bool>> ( BoolPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedBoolProperty.Name,    Is.EqualTo ( propertyName ) );
+                                 Assert.That ( updatedBoolProperty.Value,   Is.EqualTo ( propertyValue ) );
+                                 Assert.That ( updatedBoolProperty.IsLocal, Is.EqualTo ( isLocal ) );
 
-                Assert.That( updatedRecord, Is.EqualTo( originalRecord ) );
-            } );
+                                 Assert.That ( updatedRecord, Is.EqualTo ( originalRecord ) );
+                             } );
         }
         else
         {
@@ -307,11 +328,12 @@ public class ZfsRecordTests
 
         if ( !isLocal )
         {
-            Assert.Multiple( ( ) =>
-            {
-                Assert.That( updatedRecord[ propertyName ], Has.Property( "IsLocal" ).False );
-                Assert.That( updatedRecord[ propertyName ], Has.Property( "Source" ).EqualTo( $"inherited from {updatedParent.Name}" ) );
-            } );
+            Assert.Multiple (
+                             ( ) =>
+                             {
+                                 Assert.That ( updatedRecord [ propertyName ], Has.Property ( "IsLocal" ).False );
+                                 Assert.That ( updatedRecord [ propertyName ], Has.Property ( "Source" ).EqualTo ( $"inherited from {updatedParent.Name}" ) );
+                             } );
         }
     }
 
@@ -374,113 +396,120 @@ public class ZfsRecordTests
 
     [Test]
     [Combinatorial]
-    public void UpdateProperty_Int( [Values( ZfsPropertyNames.SnapshotRetentionFrequentPropertyName, ZfsPropertyNames.SnapshotRetentionHourlyPropertyName, ZfsPropertyNames.SnapshotRetentionDailyPropertyName, ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName, ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName, ZfsPropertyNames.SnapshotRetentionYearlyPropertyName, ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName )] string propertyName, [Values( 0, 1, 2, 10, 100 )] int propertyValue, [Values] bool isLocal )
+    public void UpdateProperty_Int ( [Values ( ZfsPropertyNames.SnapshotRetentionFrequentPropertyName, ZfsPropertyNames.SnapshotRetentionHourlyPropertyName, ZfsPropertyNames.SnapshotRetentionDailyPropertyName, ZfsPropertyNames.SnapshotRetentionWeeklyPropertyName, ZfsPropertyNames.SnapshotRetentionMonthlyPropertyName, ZfsPropertyNames.SnapshotRetentionYearlyPropertyName, ZfsPropertyNames.SnapshotRetentionPruneDeferralPropertyName )] string propertyName, [Values ( 0, 1, 2, 10, 100 )] int propertyValue, [Values] bool isLocal )
     {
-        ZfsRecord originalParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem( );
-        ZfsRecord originalRecord = originalParent.CreateChildDataset( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
-        ZfsRecord updatedParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem( );
-        ZfsRecord updatedRecord = updatedParent.CreateChildDataset( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
-        ZfsProperty<int> newTestCaseProperty = ZfsProperty<int>.CreateWithoutParent( propertyName, propertyValue, isLocal );
-        ZfsProperty<int> originalIntProperty = originalRecord.GetIntProperty( propertyName );
+        ZfsRecord        originalParent      = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( );
+        ZfsRecord        originalRecord      = originalParent.CreateChildDataset ( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsRecord        updatedParent       = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( );
+        ZfsRecord        updatedRecord       = updatedParent.CreateChildDataset ( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsProperty<int> newTestCaseProperty = ZfsProperty<int>.CreateWithoutParent ( propertyName, propertyValue, isLocal );
+        ZfsProperty<int> originalIntProperty = originalRecord.GetIntProperty ( propertyName );
 
-        Assume.That( updatedRecord, Is.EqualTo( originalRecord ), "Both records must be identical for this test to be valid" );
-        Assume.That( updatedRecord, Is.Not.SameAs( originalRecord ) );
+        Assume.That ( updatedRecord, Is.EqualTo ( originalRecord ), "Both records must be identical for this test to be valid" );
+        Assume.That ( updatedRecord, Is.Not.SameAs ( originalRecord ) );
 
-        ZfsProperty<int> updatedIntProperty = updatedRecord.UpdateProperty( propertyName, propertyValue, isLocal );
+        ZfsProperty<int> updatedIntProperty = updatedRecord.UpdateProperty ( propertyName, propertyValue, isLocal );
 
         if ( newTestCaseProperty == originalIntProperty )
         {
-            Assert.Multiple( ( ) =>
-            {
-                Assert.That( updatedIntProperty,         Is.EqualTo( originalIntProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
-                Assert.That( updatedIntProperty,         Is.EqualTo( newTestCaseProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
-                Assert.That( updatedIntProperty.Name,    Is.EqualTo( propertyName ) );
-                Assert.That( updatedIntProperty.Value,   Is.EqualTo( propertyValue ) );
-                Assert.That( updatedIntProperty.IsLocal, Is.EqualTo( isLocal ) );
+            Assert.Multiple (
+                             ( ) =>
+                             {
+                                 Assert.That ( updatedIntProperty,         Is.EqualTo ( originalIntProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedIntProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedIntProperty.Name,    Is.EqualTo ( propertyName ) );
+                                 Assert.That ( updatedIntProperty.Value,   Is.EqualTo ( propertyValue ) );
+                                 Assert.That ( updatedIntProperty.IsLocal, Is.EqualTo ( isLocal ) );
 
-                Assert.That( updatedRecord, Is.EqualTo( originalRecord ) );
-            } );
+                                 Assert.That ( updatedRecord, Is.EqualTo ( originalRecord ) );
+                             } );
         }
         else
         {
-            Assert.Multiple( ( ) =>
-            {
-                Assert.That( updatedIntProperty,         Is.Not.EqualTo( originalIntProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
-                Assert.That( updatedIntProperty,         Is.EqualTo( newTestCaseProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
-                Assert.That( updatedIntProperty.Name,    Is.EqualTo( propertyName ) );
-                Assert.That( updatedIntProperty.Value,   Is.EqualTo( propertyValue ) );
-                Assert.That( updatedIntProperty.IsLocal, Is.EqualTo( isLocal ) );
+            Assert.Multiple (
+                             ( ) =>
+                             {
+                                 Assert.That ( updatedIntProperty,         Is.Not.EqualTo ( originalIntProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedIntProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<int>> ( IntPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedIntProperty.Name,    Is.EqualTo ( propertyName ) );
+                                 Assert.That ( updatedIntProperty.Value,   Is.EqualTo ( propertyValue ) );
+                                 Assert.That ( updatedIntProperty.IsLocal, Is.EqualTo ( isLocal ) );
 
-                Assert.That( updatedRecord, Is.Not.EqualTo( originalRecord ) );
-            } );
+                                 Assert.That ( updatedRecord, Is.Not.EqualTo ( originalRecord ) );
+                             } );
         }
 
         if ( !isLocal )
         {
-            Assert.Multiple( ( ) =>
-            {
-                Assert.That( updatedRecord[ propertyName ], Has.Property( "IsLocal" ).False );
-                Assert.That( updatedRecord[ propertyName ], Has.Property( "Source" ).EqualTo( $"inherited from {updatedParent.Name}" ) );
-            } );
+            Assert.Multiple (
+                             ( ) =>
+                             {
+                                 Assert.That ( updatedRecord [ propertyName ], Has.Property ( "IsLocal" ).False );
+                                 Assert.That ( updatedRecord [ propertyName ], Has.Property ( "Source" ).EqualTo ( $"inherited from {updatedParent.Name}" ) );
+                             } );
         }
     }
 
     [Test]
     [Combinatorial]
-    public void UpdateProperty_String( [Values( ZfsPropertyNames.RecursionPropertyName, ZfsPropertyNames.TemplatePropertyName )] string propertyName, [Values( "default", "testTemplate", "template with spaces" )] string propertyValue, [Values] bool isLocal )
+    public void UpdateProperty_String ( [Values ( ZfsPropertyNames.RecursionPropertyName, ZfsPropertyNames.TemplatePropertyName )] string propertyName, [Values ( "default", "testTemplate", "template with spaces" )] string propertyValue, [Values] bool isLocal )
     {
-        ZfsRecord originalParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem( );
-        ZfsRecord originalRecord = originalParent.CreateChildDataset( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
-        ZfsRecord updatedParent = ZfsRecordTestHelpers.GetNewTestRootFileSystem( );
-        ZfsRecord updatedRecord = updatedParent.CreateChildDataset( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
-        ZfsProperty<string> newTestCaseProperty = ZfsProperty<string>.CreateWithoutParent( propertyName, propertyValue, isLocal );
-        ZfsProperty<string> originalStringProperty = (ZfsProperty<string>)originalRecord[ propertyName ];
+        ZfsRecord           originalParent         = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( );
+        ZfsRecord           originalRecord         = originalParent.CreateChildDataset ( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsRecord           updatedParent          = ZfsRecordTestHelpers.GetNewTestRootFileSystem ( );
+        ZfsRecord           updatedRecord          = updatedParent.CreateChildDataset ( "testRoot/fs1", ZfsPropertyValueConstants.FileSystem, "testSystem" );
+        ZfsProperty<string> newTestCaseProperty    = ZfsProperty<string>.CreateWithoutParent ( propertyName, propertyValue, isLocal );
+        ZfsProperty<string> originalStringProperty = (ZfsProperty<string>)originalRecord [ propertyName ];
 
-        Assume.That( updatedRecord, Is.EqualTo( originalRecord ), "Both records must be identical for this test to be valid" );
-        Assume.That( updatedRecord, Is.Not.SameAs( originalRecord ) );
+        Assume.That ( updatedRecord, Is.EqualTo ( originalRecord ), "Both records must be identical for this test to be valid" );
+        Assume.That ( updatedRecord, Is.Not.SameAs ( originalRecord ) );
 
-        ZfsProperty<string> updatedStringProperty = updatedRecord.UpdateProperty( propertyName, propertyValue, isLocal );
+        ZfsProperty<string> updatedStringProperty = updatedRecord.UpdateProperty ( propertyName, propertyValue, isLocal );
 
         if ( newTestCaseProperty == originalStringProperty )
         {
-            Assert.Multiple( ( ) =>
+            Assert.Multiple (
+                             ( ) =>
                              {
-                                 Assert.That ( updatedStringProperty, Is.EqualTo ( originalStringProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
-                Assert.That( updatedStringProperty,                   Is.EqualTo( newTestCaseProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
-                Assert.That( updatedStringProperty.Name,              Is.EqualTo( propertyName ) );
-                Assert.That( updatedStringProperty.Value,             Is.EqualTo( propertyValue ) );
-                Assert.That( updatedStringProperty.IsLocal,           Is.EqualTo( isLocal ) );
+                                 Assert.That ( updatedStringProperty,         Is.EqualTo ( originalStringProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedStringProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedStringProperty.Name,    Is.EqualTo ( propertyName ) );
+                                 Assert.That ( updatedStringProperty.Value,   Is.EqualTo ( propertyValue ) );
+                                 Assert.That ( updatedStringProperty.IsLocal, Is.EqualTo ( isLocal ) );
 
-                Assert.That( updatedRecord, Is.EqualTo( originalRecord ) );
-            } );
+                                 Assert.That ( updatedRecord, Is.EqualTo ( originalRecord ) );
+                             } );
         }
         else
         {
-            Assert.Multiple( ( ) =>
-            {
-                Assert.That( updatedStringProperty,         Is.Not.EqualTo( originalStringProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
-                Assert.That( updatedStringProperty,         Is.EqualTo( newTestCaseProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
-                Assert.That( updatedStringProperty.Name,    Is.EqualTo( propertyName ) );
-                Assert.That( updatedStringProperty.Value,   Is.EqualTo( propertyValue ) );
-                Assert.That( updatedStringProperty.IsLocal, Is.EqualTo( isLocal ) );
+            Assert.Multiple (
+                             ( ) =>
+                             {
+                                 Assert.That ( updatedStringProperty,         Is.Not.EqualTo ( originalStringProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedStringProperty,         Is.EqualTo ( newTestCaseProperty ).Using<ZfsProperty<string>> ( StringPropertyComparer_Force_op_Equality ) );
+                                 Assert.That ( updatedStringProperty.Name,    Is.EqualTo ( propertyName ) );
+                                 Assert.That ( updatedStringProperty.Value,   Is.EqualTo ( propertyValue ) );
+                                 Assert.That ( updatedStringProperty.IsLocal, Is.EqualTo ( isLocal ) );
 
-                Assert.That( updatedRecord, Is.Not.EqualTo( originalRecord ) );
-            } );
+                                 Assert.That ( updatedRecord, Is.Not.EqualTo ( originalRecord ) );
+                             } );
         }
 
         if ( !isLocal )
         {
-            Assert.Multiple( ( ) =>
-            {
-                Assert.That( updatedRecord[ propertyName ], Has.Property( "IsLocal" ).False );
-                Assert.That( updatedRecord[ propertyName ], Has.Property( "Source" ).EqualTo( $"inherited from {updatedParent.Name}" ) );
-            } );
+            Assert.Multiple (
+                             ( ) =>
+                             {
+                                 Assert.That ( updatedRecord [ propertyName ], Has.Property ( "IsLocal" ).False );
+                                 Assert.That ( updatedRecord [ propertyName ], Has.Property ( "Source" ).EqualTo ( $"inherited from {updatedParent.Name}" ) );
+                             } );
         }
     }
 
-    private static ZfsProperty<bool> GetBoolPropertyByValueFromDataset ( ZfsRecord dataset, string propertyName ) => (ZfsProperty<bool>)dataset [ propertyName ];
-    private static bool DateTimeOffsetPropertyComparer_Force_op_Equality ( ZfsProperty<DateTimeOffset> left, ZfsProperty<DateTimeOffset> right ) => left == right;
     private static bool BoolPropertyComparer_Force_op_Equality ( ZfsProperty<bool>                     left, ZfsProperty<bool>           right ) => left == right;
-    private static bool IntPropertyComparer_Force_op_Equality ( ZfsProperty<int>                       left, ZfsProperty<int>            right ) => left == right;
-    private static bool StringPropertyComparer_Force_op_Equality ( ZfsProperty<string>                 left, ZfsProperty<string>         right ) => left == right;
+    private static bool DateTimeOffsetPropertyComparer_Force_op_Equality ( ZfsProperty<DateTimeOffset> left, ZfsProperty<DateTimeOffset> right ) => left == right;
+
+    private static ZfsProperty<bool> GetBoolPropertyByValueFromDataset ( ZfsRecord                  dataset, string              propertyName ) => (ZfsProperty<bool>)dataset [ propertyName ];
+    private static bool              IntPropertyComparer_Force_op_Equality ( ZfsProperty<int>       left,    ZfsProperty<int>    right )        => left == right;
+    private static bool              StringPropertyComparer_Force_op_Equality ( ZfsProperty<string> left,    ZfsProperty<string> right )        => left == right;
 }


### PR DESCRIPTION
Alrighty. I'm bored with the cleanup work for this round, so I'm calling a cutoff for now so I can do something more interesting.

The majority of this change set is formatting and filling in some missing XmlDoc comments.

However, there are also some test improvements, mainly around ensuring that the tests that were touched explicitly are being told to use the equality operator for equality comparison of `ZfsProperty<T>` values, rather than NUnit trying to guess and often ending up calling object.Equals instead, which is not what the code will actually call when equality is tested, since those operators are defined on the types and are included via some interfaces, as well.

The only two potentially "breaking" changes made are:

 - One case of checking a string parameter for null was changed from a string.IsNullOrWhitespace check with an explicit throw to the ArgumentException.ThrowIfNullOrWhitespace throw helper, which has the effect of ArgumentException being thrown when empty or whitespace and ArgumentNullException being thrown if null. Previously, ArgumentNullException was always thrown, which would be inaccurate if the argument was empty or whitespace.
 - The `ZfsProperty<T>` struct was changed to a `readonly struct`. Most of its fields were already readonly, so this should not have any practical impact on code that was abusing the intended use of the type, but it's still worth mentioning as there could conceivably be corner cases I haven't conceived of that are outside of SIAZ' use of that type.

There were some minor _additions_ made on `ZfsProperty<T>`, as well, which were aimed at helping to ensure consistent behavior of equality comparisons both in the current state of things and if other types, internally or externally, are used as type parameters for that struct. Additional interfaces were implemented to formalize and advertise that contract, and the implementations delegate to existing methods when possible and fall back to the default comparer of the type parameter for types not currently explicitly implemented in `ZfsProperty<T>`, while still allowing the same constraint of `notnull` to stand. In current code, this actually did make some tests call the intended operator, which provided the same result as before but is a more precise implementation, now.

Some of the changes made have a very small performance benefit (such as grabbing explicitly named loggers instead of making NLog figure it out via reflection and stack walking) but, aside from the change to the exception I just mentioned, there are no behavior changes, and all tests continue to pass for all of the same cases.

NOT ALL OF THE CODE HAS BEEN TOUCHED FOR THIS PASS.

This was just me opportunistically touching and cleaning up code from the random point I started at and basically organically following from there, plus some sequential progression through one folder. I'll do more cleanup in the future, both as part of dedicated branches like this and opportunistically during feature branches, and I'll continue to commit as always, attempting to separate pure formatting and cleanup changes from everything else, so things are as easy to follow and as clear regarding my intent as possible. ...If anyone ever reads the history or this PR comment. 😅

You'd think I was paid by the word or something, right? Sadly, no, aside from the slight enjoyment I might get out of making someone somewhere groan with my lame commentary like this. 🙂 

Anyway, this is ready to merge into the project's cleanup branch, which I'll likely then also just merge right into siaz-2.0 and then to master, for a release tag.

This completes https://github.com/snapsinazfs/snapsinazfs/issues/47