### PR TITLE
Update build-and-test-* workflows to use current setup-dotnet action

### DIFF
--- a/.github/workflows/build-and-test-build-tag.yml
+++ b/.github/workflows/build-and-test-build-tag.yml
@@ -8,12 +8,12 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, centos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v4.3.0
       with:
         dotnet-version: 8.0.x
     - name: Restore dependencies


### PR DESCRIPTION
What it says on the tin

Updating that action to current from the old v3