### PR TITLE
Update readme for development change to 3.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 [![Latest 'release' Tag Status](https://github.com/snapsinazfs/snapsinazfs/actions/workflows/build-and-test-release-tag.yml/badge.svg)](https://github.com/snapsinazfs/snapsinazfs/actions/workflows/build-and-test-release-tag.yml)
  
  Current stable release version: 2.0.3\
- Current development branch: siaz-2.1
+ Current development branch: siaz-3.0
 
- Stable and pre-release versions are available on GitHub in the Releases section. Cloning the repository for local production builds is only recommended from release-2.x.y tags with no hyphenated text after the version number, which indicates pre-release).
+ Stable and pre-release versions are available on GitHub in the Releases section. Cloning the repository for local production builds is only recommended from release-M.m.p tags with no hyphenated text after the version number, which indicates pre-release).
 
  Please report any issues in the issue tracker, with as much detail as you can provide. Detailed logs are greatly appreciated and do not reveal secret information beyond the names of your ZFS datasets and snapshots.
 
  ## Requirements
 
- SIAZ is built in c\# on .net 10, and strives to require no other external dependencies to be manually installed other than the .net 10 runtim or .net 10 SDK (to build from source), and a supported version of ZFS (currently 2.1 and up).\
+ SIAZ is built in c\# on .net 10, and strives to require no other external dependencies to be manually installed other than the .net 10 runtim or .net 10 SDK (to build from source), and a supported version of ZFS (currently 2.2 and up).\
  Building SIAZ also requires standard command-line utilities that typically exist on any supported Linux distribution, such as `install`, `cp`, and the like.
 
  SIAZ will likely build and run on any modern Linux system that supports the required .NET version and ZFS on Linux version.\
@@ -35,7 +35,7 @@
    - If you are using a pre-built version of SIAZ (not yet provided here), the .net 10.0 runtime is sufficient
    - If you are building from source, the .net 10.0 SDK is required. `make` is an optional dependency for a simplified build workflow familiar to Linux users.
    - If you are using a pre-built AOT-compiled version of SIAZ or a pre-build framework-independent version of SIAZ (not yet provided here), you do not need ANY .net components installed, but it is your responsibility to ensure binary compatibility with the target system.
- - ZFS version 2.1 or higher
+ - ZFS version 2.2 or higher
    - Some features may require higher ZFS versions. That is and will be documented when relevant. It is your responsibility to ensure ZFS compatibility, in the version of the kernel module, the userspace utilities, and in the necessary feature flags on pools/datasets, where relevant.
    - Live testing against ZFS is performed against version 2.2 and 2.3, at present, so I suggest 2.2 or higher.
    - While basic operation of SIAZ is likely compatible with earlier ZFS versions, such compatibility could change with any new SIAZ release and is NOT guaranteed or supported.


### PR DESCRIPTION
Biggest reasons for the major version increment are new minimum .net and ZFS versions, and other major architectural changes coming in 3.0 (chiefly-direct libzfs integration to eliminate process launch overhead)
